### PR TITLE
fix CONTAINER_NAME env indent

### DIFF
--- a/config/500-dispatcher.yaml
+++ b/config/500-dispatcher.yaml
@@ -46,8 +46,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-          - name: CONTAINER_NAME
-            value: dispatcher
+            - name: CONTAINER_NAME
+              value: dispatcher
           ports:
             - containerPort: 9090
               name: metrics


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@vmware.com>

Fixes the nightly release. Indent was off.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Intent the CONTAINER_NAME env correctly.
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fix bug

Fix the intendation properly.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
