### PR TITLE
use go 1.15 on kind e2e

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -54,10 +54,10 @@ jobs:
           echo "SLACK_WEBHOOK=exists" >> $GITHUB_ENV
         fi
 
-    - name: Set up Go 1.14.x
+    - name: Set up Go 1.15.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.14.x
+        go-version: 1.15.x
 
     - name: Install Dependencies
       run: |


### PR DESCRIPTION
Use go 1.15 for kind e2e tests

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

-Use go 1.15 for kind e2e tests

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- :broom: Update or clean up current behavior - Use go 1.15 in kind e2e tests.

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
