### PR TITLE
Change release label from rabbitmq to natss

### DIFF
--- a/config/201-webhook-serviceaccount.yaml
+++ b/config/201-webhook-serviceaccount.yaml
@@ -18,7 +18,7 @@ metadata:
   name: natss-webhook
   namespace: knative-eventing
   labels:
-    rabbitmq.eventing.knative.dev/release: devel
+    natss.eventing.knative.dev/release: devel
 
 ---
 
@@ -27,7 +27,7 @@ kind: ClusterRoleBinding
 metadata:
   name: natss-webhook
   labels:
-    rabbitmq.eventing.knative.dev/release: devel
+    natss.eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: natss-webhook


### PR DESCRIPTION
## Proposed Changes

- Change release label from rabbitmq to natss

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Change release label of clusterrole and service account from rabbitmq to natss
```
