### PR TITLE
Make dispatcher subscription options configurable

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -76,3 +76,13 @@ env:
       fieldRef:
         fieldPath: metadata.namespace
 ```
+
+NATS dispatchers subscriptions can be configured by the following environment variables:
+
+```yaml
+env:
+  - name: ACK_WAIT_MINUTES
+    value: "1"
+  - name: MAX_INFLIGHT
+    value: "1024"
+```

--- a/pkg/reconciler/dispatcher/natsschannel.go
+++ b/pkg/reconciler/dispatcher/natsschannel.go
@@ -97,9 +97,11 @@ func NewController(ctx context.Context, _ configmap.Watcher) *controller.Impl {
 	natssConfig := util.GetNatssConfig()
 	reporter := channel.NewStatsReporter(env.ContainerName, kmeta.ChildName(env.PodName, uuid.New().String()))
 	dispatcherArgs := dispatcher.Args{
-		NatssURL:  util.GetDefaultNatssURL(),
-		ClusterID: util.GetDefaultClusterID(),
-		ClientID:  natssConfig.ClientID,
+		NatssURL:       util.GetDefaultNatssURL(),
+		ClusterID:      util.GetDefaultClusterID(),
+		ClientID:       natssConfig.ClientID,
+		AckWaitMinutes: util.GetAckWaitMinutes(),
+		MaxInflight:    util.GetMaxInflight(),
 		Cargs: kncloudevents.ConnectionArgs{
 			MaxIdleConns:        natssConfig.MaxIdleConns,
 			MaxIdleConnsPerHost: natssConfig.MaxIdleConnsPerHost,

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -3,6 +3,7 @@ package util
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	"knative.dev/pkg/network"
 )
@@ -11,9 +12,13 @@ const (
 	// DefaultNatssURLKey is the environment variable that can be set to specify the natss url
 	defaultNatssURLVar  = "DEFAULT_NATSS_URL"
 	defaultClusterIDVar = "DEFAULT_CLUSTER_ID"
+	ackWaitMinutesVar   = "ACK_WAIT_MINUTES"
+	maxInflightVar      = "MAX_INFLIGHT"
 
 	fallbackDefaultNatssURLTmpl = "nats://nats-streaming.natss.svc.%s:4222"
 	fallbackDefaultClusterID    = "knative-nats-streaming"
+	fallbackAckWaitMinutes      = 1
+	fallbackMaxInflight         = 1024
 
 	defaultMaxIdleConnections        = 1000
 	defaultMaxIdleConnectionsPerHost = 100
@@ -45,6 +50,14 @@ func GetDefaultClusterID() string {
 	return getEnv(defaultClusterIDVar, fallbackDefaultClusterID)
 }
 
+func GetAckWaitMinutes() int {
+	return getEnvAsInt(ackWaitMinutesVar, fallbackAckWaitMinutes)
+}
+
+func GetMaxInflight() int {
+	return getEnvAsInt(maxInflightVar, fallbackMaxInflight)
+}
+
 // getMaxIdleConnections returns the max number of idle connections
 func getMaxIdleConnections() int {
 	return defaultMaxIdleConnections
@@ -61,4 +74,12 @@ func getEnv(envKey string, fallback string) string {
 		return fallback
 	}
 	return val
+}
+
+func getEnvAsInt(envKey string, fallback int) int {
+	valueStr := getEnv(envKey, "")
+	if value, err := strconv.Atoi(valueStr); err == nil {
+		return value
+	}
+	return fallback
 }


### PR DESCRIPTION
…(#1)

We had issues with slow consumers and it was necessary to either set `MAX_INFLIGHT` to one or increase `ACK_WAIT_MINUTES` to make eventing working in our environment. I just made them configurable to be able to tune them easily.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add environment variables `MAX_INFLIGHT` and `ACK_WAIT_MINUTES` to configure nats subscription

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NATS dispatchers subscriptions can be configured by the environment variables `ACK_WAIT_MINUTES` and `MAX_INFLIGHT`.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
