### PR TITLE
Allow JWT and NKey credentials with JetStream

### DIFF
--- a/pkg/natsutil/jetstreamutil.go
+++ b/pkg/natsutil/jetstreamutil.go
@@ -2,7 +2,6 @@ package natsutil
 
 import (
 	"github.com/nats-io/nats.go"
-
 	"go.uber.org/zap"
 )
 
@@ -15,9 +14,18 @@ const (
 )
 
 // JetStreamConnect creates a new NATS JetStream connection
-func JetStreamConnect(jetStreamUrl string, logger *zap.SugaredLogger) (*nats.Conn, error) {
+func JetStreamConnect(jetStreamUrl string, logger *zap.SugaredLogger, natsUserOrChainedFile string, natsSeedFiles []string) (*nats.Conn, error) {
 	logger.Infof("JetStreamConnect():  jetStreamUrl: %v", jetStreamUrl)
-	nc, err := nats.Connect(jetStreamUrl)
+
+	var nc *nats.Conn
+	var err error
+
+	if natsUserOrChainedFile == "" || natsSeedFiles == nil || len(natsSeedFiles) == 0 {
+		nc, err = nats.Connect(jetStreamUrl)
+	} else {
+		nc, err = nats.Connect(jetStreamUrl, nats.UserCredentials(natsUserOrChainedFile, natsSeedFiles...))
+	}
+
 	if err != nil {
 		logger.Errorf("Connect(): create new connection failed: %v", err)
 		return nil, err

--- a/pkg/reconciler/dispatcher/jetstream/nats_jetstreaming_schannel.go
+++ b/pkg/reconciler/dispatcher/jetstream/nats_jetstreaming_schannel.go
@@ -94,7 +94,9 @@ func NewController(ctx context.Context, _ configmap.Watcher) *controller.Impl {
 	//natssConfig := util.GetNatssConfig()
 	reporter := channel.NewStatsReporter(env.ContainerName, kmeta.ChildName(env.PodName, uuid.New().String()))
 	dispatcherArgs := dispatcher.JetArgs{
-		JetStreamURL: util.GetDefaultJetStreamURL(),
+		JetStreamURL:          util.GetDefaultJetStreamURL(),
+		NatsUserOrChainedFile: util.GetDefaultNatsUserOrChainedFile(),
+		NatsSeedFiles:         util.GetDefaultNatsSeedFiles(),
 		//Cargs: kncloudevents.ConnectionArgs{
 		//	MaxIdleConns:        natssConfig.MaxIdleConns,
 		//	MaxIdleConnsPerHost: natssConfig.MaxIdleConnsPerHost,

--- a/pkg/util/jetstreamutil.go
+++ b/pkg/util/jetstreamutil.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"fmt"
+	"strings"
 
 	"knative.dev/pkg/network"
 )
@@ -26,10 +27,27 @@ const (
 	// defaultJetStreamURLVar is the environment variable that can be set to specify the nats jetStream url
 	defaultJetStreamURLVar = "DEFAULT_JETSTREAM_URL"
 
+	defaultNatsUserOrChainedFile = "DEFAULT_USER_OR_CHAINED_FILE"
+	defaultNatsSeedFiles         = "DEFAULT_SEED_FILES"
+
 	fallbackDefaultJetStreamURLTmpl = "nats://jet-stream.nats.svc.%s:4222"
 )
 
 // GetDefaultJetStreamURL returns the default jet stream url to connect to
 func GetDefaultJetStreamURL() string {
 	return getEnv(defaultJetStreamURLVar, fmt.Sprintf(fallbackDefaultJetStreamURLTmpl, network.GetClusterDomainName()))
+}
+
+// GetDefaultNatsUserOrChainedFile returns the default user or chained file
+func GetDefaultNatsUserOrChainedFile() string {
+	return getEnv(defaultNatsUserOrChainedFile, "")
+}
+
+// GetDefaultNatsSeedFiles returns the default seed files (comma separated)
+func GetDefaultNatsSeedFiles() []string {
+	seedFiles := getEnv(defaultNatsSeedFiles, "")
+	if seedFiles == "" {
+		return nil
+	}
+	return strings.Split(seedFiles, ",")
 }


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

As of now, connection to NATS only works:
- without credentials (e.g. `nats://host:4222`)
- or with basic authentication (e.g. `nats://derek:pass@host:4222`, see https://github.com/knative-sandbox/eventing-natss/blob/4080495/vendor/github.com/nats-io/nats.go/nats.go#L696).

## Proposed Changes

- 🎁 introduce JWT and NKeys (https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/jwt) to access NATS

I have reused the terms "user or chained file" and "seed files" from NATS `UserCredentials` method: https://github.com/knative-sandbox/eventing-natss/blob/4080495/vendor/github.com/nats-io/nats.go/nats.go#L981.

### Usage

#### Create auth files

user-or-chained-file
```
-----BEGIN NATS USER JWT-----
eyJ0...
------END NATS USER JWT------
```

seed-file
```
-----BEGIN USER NKEY SEED-----
SUAL...
------END USER NKEY SEED------
```

#### Create a k8s secret

```
kubectl create secret generic -n knative-eventing nats-creds \
    --from-file user-or-chained-file \
    --from-file seed-file
```

#### Patch the jetstream dispatcher

Mount secrets as files and use them in environment variables:

```patch
diff --git a/config/501-jetstream-dispatcher.yaml b/config/501-jetstream-dispatcher-auth.yaml
--- a/config/501-jetstream-dispatcher.yaml
+++ b/config/501-jetstream-dispatcher-auth.yaml
@@ -51,7 +51,11 @@ spec:
             - name: METRICS_DOMAIN
               value: knative.dev/eventing
             - name: DEFAULT_JETSTREAM_URL
-              value: nats://jetstream.nats.svc.cluster.local:4222
+              value: nats://path.to.nats:4222
+            - name: DEFAULT_USER_OR_CHAINED_FILE
+              value: /etc/secrets/user-or-chained-file
+            - name: DEFAULT_SEED_FILES
+              value: /etc/secrets/seed-file
             - name: SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -71,7 +75,12 @@ spec:
           volumeMounts:
             - name: config-logging
               mountPath: /etc/config-logging
+            - name: nats-creds
+              mountPath: /etc/secrets
       volumes:
         - name: config-logging
           configMap:
             name: config-logging
+        - name: nats-creds
+          secret:
+            secretName: nats-creds
```

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Allow JWT and NKey authentication with JetStream
```