### PR TITLE
implemented propagating w3c tracing context headers via stan channels…

### DIFF
--- a/pkg/dispatcher/natss_dispatcher.go
+++ b/pkg/dispatcher/natss_dispatcher.go
@@ -19,6 +19,7 @@ package dispatcher
 import (
 	"context"
 	"fmt"
+	"go.opencensus.io/trace"
 	"net/http"
 	"net/url"
 	"sync"
@@ -39,6 +40,7 @@ import (
 	"knative.dev/eventing/pkg/kncloudevents"
 
 	"knative.dev/eventing-natss/pkg/natsutil"
+	"knative.dev/eventing-natss/pkg/tracing"
 )
 
 const (
@@ -147,7 +149,9 @@ func messageReceiverFunc(s *subscriptionsSupervisor) eventingchannels.Unbuffered
 			s.logger.Error("could not create natss sender", zap.Error(err))
 			return errors.Wrap(err, "could not create natss sender")
 		}
-		if err := sender.Send(ctx, message); err != nil {
+
+		tpTsTransformers := tracing.SerializeTraceTransformers(trace.FromContext(ctx).SpanContext())
+		if err := sender.Send(ctx, message, tpTsTransformers...); err != nil {
 			errMsg := "error during send"
 			if err.Error() == stan.ErrConnectionClosed.Error() {
 				errMsg += " - connection to NATSS has been lost, attempting to reconnect"
@@ -320,7 +324,13 @@ func (s *subscriptionsSupervisor) subscribe(ctx context.Context, channel eventin
 			s.logger.Debug("dispatch message", zap.String("deadLetter", deadLetter.String()))
 		}
 
-		executionInfo, err := s.dispatcher.DispatchMessage(ctx, message, nil, destination, reply, deadLetter)
+		event := tracing.ConvertNatssMsgToEvent(s.logger, stanMsg)
+		additionalHeaders := tracing.ConvertEventToHttpHeader(event)
+
+		ctx, span := tracing.StartTraceFromMessage(s.logger, ctx, event, "natsschannel-"+channel.Name)
+		defer span.End()
+
+		executionInfo, err := s.dispatcher.DispatchMessage(ctx, message, additionalHeaders, destination, reply, deadLetter)
 		if err != nil {
 			s.logger.Error("Failed to dispatch message: ", zap.Error(err))
 			return

--- a/pkg/reconciler/dispatcher/natss/natsschannel.go
+++ b/pkg/reconciler/dispatcher/natss/natsschannel.go
@@ -19,6 +19,9 @@ package natss
 import (
 	"context"
 	"fmt"
+	configmapinformer "knative.dev/pkg/configmap/informer"
+	"knative.dev/pkg/tracing"
+	tracingconfig "knative.dev/pkg/tracing/config"
 	"strings"
 
 	"github.com/google/uuid"
@@ -82,9 +85,15 @@ type envConfig struct {
 
 // NewController initializes the controller and is called by the generated code.
 // Registers event handlers to enqueue events.
-func NewController(ctx context.Context, _ configmap.Watcher) *controller.Impl {
+func NewController(ctx context.Context, watcher configmap.Watcher) *controller.Impl {
 
 	logger := logging.FromContext(ctx)
+
+	// Setup trace publishing.
+	iw := watcher.(*configmapinformer.InformedWatcher)
+	if err := tracing.SetupDynamicPublishing(logger, iw, controllerAgentName, tracingconfig.ConfigName); err != nil {
+		logger.Panicw("Error setting up trace publishing", zap.Error(err))
+	}
 
 	var env envConfig
 	if err := envconfig.Process("", &env); err != nil {

--- a/pkg/reconciler/dispatcher/natss/natsschannel_test.go
+++ b/pkg/reconciler/dispatcher/natss/natsschannel_test.go
@@ -19,6 +19,7 @@ package natss
 import (
 	"context"
 	"fmt"
+	configmapinformer "knative.dev/pkg/configmap/informer"
 	"os"
 	"testing"
 
@@ -34,7 +35,6 @@ import (
 	"knative.dev/pkg/apis"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/service/fake"
-	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection"
 	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
@@ -208,7 +208,7 @@ func TestNewController(t *testing.T) {
 	ctx = injection.WithConfig(ctx, cfg)
 	ctx, _ = injection.Fake.SetupInformers(ctx, cfg)
 
-	NewController(ctx, configmap.NewStaticWatcher())
+	NewController(ctx, &configmapinformer.InformedWatcher{})
 }
 
 func TestFailedNatssSubscription(t *testing.T) {

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -1,0 +1,85 @@
+package tracing
+
+import (
+	"context"
+	"encoding/json"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/binding/transformer"
+	"github.com/cloudevents/sdk-go/v2/event"
+	"github.com/nats-io/stan.go"
+	"go.opencensus.io/plugin/ochttp/propagation/tracecontext"
+	"go.opencensus.io/trace"
+	"go.uber.org/zap"
+	"net/http"
+)
+
+const (
+	traceParentHeader = "traceparent"
+	traceStateHeader  = "tracestate"
+)
+
+var (
+	format = tracecontext.HTTPFormat{}
+)
+
+func SerializeTraceTransformers(spanContext trace.SpanContext) []binding.Transformer {
+	tp, ts := format.SpanContextToHeaders(spanContext)
+	return []binding.Transformer{
+		keyValTransformer(traceParentHeader, tp),
+		keyValTransformer(traceStateHeader, ts),
+	}
+}
+
+func keyValTransformer(key string, value string) binding.TransformerFunc {
+	return transformer.SetExtension(key, func(_ interface{}) (interface{}, error) {
+		return value, nil
+	})
+}
+
+func StartTraceFromMessage(logger *zap.Logger, inCtx context.Context, message *event.Event, spanName string) (context.Context, *trace.Span) {
+	sc, ok := parseSpanContext(message)
+	if !ok {
+		logger.Warn("Cannot parse the spancontext, creating a new span")
+		return trace.StartSpan(inCtx, spanName)
+	}
+
+	return trace.StartSpanWithRemoteParent(inCtx, spanName, sc)
+}
+
+func parseSpanContext(message *event.Event) (sc trace.SpanContext, ok bool) {
+	if message == nil {
+		return trace.SpanContext{}, false
+	}
+	tp, ok := message.Extensions()[traceParentHeader].(string)
+	if !ok {
+		return trace.SpanContext{}, false
+	}
+	ts := message.Extensions()[traceStateHeader].(string)
+
+	return format.SpanContextFromHeaders(tp, ts)
+}
+
+func ConvertEventToHttpHeader(message *event.Event) http.Header {
+	additionalHeaders := http.Header{}
+	if message == nil {
+		return additionalHeaders
+	}
+	tp := message.Extensions()[traceParentHeader].(string)
+	ts := message.Extensions()[traceStateHeader].(string)
+	additionalHeaders.Add(traceParentHeader, tp)
+	additionalHeaders.Add(traceStateHeader, ts)
+
+	return additionalHeaders
+}
+
+func ConvertNatssMsgToEvent(logger *zap.Logger, stanMsg *stan.Msg) *event.Event {
+	message := cloudevents.NewEvent()
+	err := json.Unmarshal(stanMsg.Data, &message)
+	if err != nil {
+		logger.Error("could not create a event from stan msg", zap.Error(err))
+		return nil
+	}
+
+	return &message
+}


### PR DESCRIPTION
Fixes #

Eventing-natss did not have tracing implemented. After configuring [eventing tracing](https://knative.dev/docs/eventing/accessing-traces/#configuring-tracing) trace did not look right way. Eventing-natss dispatcher did not pass traceparent via stan channel.

Let's consider a simple scenario (analogue to [distributed-tracing](https://knative.dev/blog/articles/distributed-tracing/))
heartbit-srv -> broker -> filter -> event-display-srv
Tracing was stored as two separate tracing:
![Screenshot from 2022-06-03 15-31-50](https://user-images.githubusercontent.com/2878309/174058849-434fffa6-4b11-45e1-a4d5-7622118192dc.png)
![Screenshot from 2022-06-03 15-31-24](https://user-images.githubusercontent.com/2878309/174058852-34015986-65c8-4631-8243-6a4d33dee52e.png)

## Proposed Changes
Enable tracing config and implement passing traceparent and tracestate w3c headers via stan channels.

After this PR is applied tracing is looking like this:
![Screenshot from 2022-06-15 18-06-13](https://user-images.githubusercontent.com/2878309/174059239-00047bc0-da41-4152-9735-95518ded23fe.png)

- 🐛 Fix bug

```release-note
Enabled tracing for NatssChannel objects.
```

P.S.: this may helpful for jetstream implementation as well