### PR TITLE
Removes the deprecated DeadLetterChannel in ChannelableStatus

### DIFF
--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -39,14 +39,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -39,14 +39,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/reconciler/dispatcher/jetstream/nats_jetstreaming_schannel.go
+++ b/pkg/reconciler/dispatcher/jetstream/nats_jetstreaming_schannel.go
@@ -288,7 +288,6 @@ func toChannel(jetStreamChannel *v1alpha1.NatsJetStreamChannel) *messagingv1.Cha
 						URL: jetStreamChannel.Status.Address.URL,
 					}},
 				SubscribableStatus: eventingduckv1.SubscribableStatus{},
-				DeadLetterChannel:  nil,
 			},
 			Channel: nil,
 		}

--- a/pkg/reconciler/dispatcher/natss/natsschannel.go
+++ b/pkg/reconciler/dispatcher/natss/natsschannel.go
@@ -288,7 +288,6 @@ func toChannel(natssChannel *v1beta1.NatssChannel) *messagingv1.Channel {
 						URL: natssChannel.Status.Address.URL,
 					}},
 				SubscribableStatus: eventingduckv1.SubscribableStatus{},
-				DeadLetterChannel:  nil,
 			},
 			Channel: nil,
 		}


### PR DESCRIPTION
Signed-off-by: Vishal Choudhary <sendtovishalchoudhary@gmail.com>

Fixes #388 
Context: 
- https://github.com/knative/eventing/pull/6722
- https://github.com/knative/eventing/issues/6720

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please catagorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behaviour
- :wastebasket: Remove feature or internal logic
-->

-  :wastebasket: Remove feature or internal logic
- removes deprecated `DeadLetterChannel`

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [x] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
removes deprecated DeadLetterChannel in favor of DeliveryStatus
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

