### PR TITLE
Upgrade kind to Kubernetes v1.25.3

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.24.0
+        - v1.25.3
 
         eventing-version:
         - knative-v1.10.1
@@ -24,9 +24,9 @@ jobs:
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.9.0
         include:
-        - k8s-version: v1.24.0
-          kind-version: v0.14.0
-          kind-image-sha: sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e
+        - k8s-version: v1.25.3
+          kind-version: v0.17.0
+          kind-image-sha: sha256:cd248d1438192f7814fbca8fede13cfe5b9918746dfa12583976158a834fd5c5
     env:
       KO_DOCKER_REPO: kind.local
       SYSTEM_NAMESPACE: knative-eventing


### PR DESCRIPTION
Currently the e2e tests run on Kubernetes 1.24. This leads to some incompatible issues with the dependency bump (see https://github.com/knative-sandbox/eventing-natss/pull/411#issuecomment-1630572476). 

This PR addresses it and bumps to Kubernetes 1.25.3 for the Kind e2e tests. 

Requires #413 to be merged first, otherwise we get errors about missing apis
```
error: resource mapping not found for name: "eventing-webhook" namespace: "knative-eventing" from "https://github.com/knative/eventing/releases/download/knative-v1.5.0/eventing-core.yaml": no matches for kind "PodDisruptionBudget" in version "policy/v1beta1"
```