### PR TITLE
Upgrade e2e tests to eventing v1.10.1

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -18,7 +18,7 @@ jobs:
         - v1.24.0
 
         eventing-version:
-        - knative-v1.5.0
+        - knative-v1.10.1
 
         # Map between K8s and KinD versions.
         # This is attempting to make it a bit clearer what's being tested.


### PR DESCRIPTION
Currently the e2e tests run against an old eventing version (v1.5.0). This PR addresses it and upgrades the kind tests to use eventing 1.10.1 