### PR TITLE
[release-1.22] make and webhook separate artifacts

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -24,7 +24,7 @@ export GO111MODULE=on
 # Yaml files to generate, and the source config dir for them.
 declare -A COMPONENTS
 COMPONENTS=(
-  ["eventing-jsm.yaml"]="./config/webhook,./config/jetstream"
+  ["eventing-jsm.yaml"]="./config/jetstream"
   ["broker-jsm.yaml"]="./config/broker"
   ["webhook-jsm.yaml"]="./config/webhook"
 )

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -25,7 +25,8 @@ export GO111MODULE=on
 declare -A COMPONENTS
 COMPONENTS=(
   ["eventing-jsm.yaml"]="./config/webhook,./config/jetstream"
-  ["broker-jsm.yaml"]="./config/webhook,./config/broker"
+  ["broker-jsm.yaml"]="./config/broker"
+  ["webhook-jsm.yaml"]="./config/webhook"
 )
 readonly COMPONENTS
 

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -24,8 +24,9 @@ export GO111MODULE=on
 # Yaml files to generate, and the source config dir for them.
 declare -A COMPONENTS
 COMPONENTS=(
-  ["eventing-jsm.yaml"]="./config/jetstream"
-  ["broker-jsm.yaml"]="./config/broker"
+  ["eventing-jsm.yaml"]="./config/webhook,./config/jetstream"
+  ["broker-jsm.yaml"]="./config/webhook,./config/broker"
+  ["broker-only-jsm.yaml"]="./config/broker"
   ["webhook-jsm.yaml"]="./config/webhook"
 )
 readonly COMPONENTS


### PR DESCRIPTION
## Proposed Changes

split artifacts into separate files so it is possible to install both or only one implmementation into a k8s.

```release-note
make broker, channel and webhook separate artifacts
```