### PR TITLE
split webhook from broker and channel

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -24,8 +24,9 @@ export GO111MODULE=on
 # Yaml files to generate, and the source config dir for them.
 declare -A COMPONENTS
 COMPONENTS=(
-  ["eventing-jsm.yaml"]="./config/webhook,./config/jetstream"
-  ["broker-jsm.yaml"]="./config/webhook,./config/broker"
+  ["eventing-jsm.yaml"]="./config/jetstream"
+  ["broker-jsm.yaml"]="./config/broker"
+  ["webhook-jsm.yaml"]="./config/webhook"
 )
 readonly COMPONENTS
 


### PR DESCRIPTION
split artifacts into separate files so it is possible to install both or only one implmementation into a k8s.

**Release Note**


```release-note
make broker, channel and webhook separate artifacts
```
