### PR TITLE
share ingress uses config map now

### DIFF
--- a/cmd/ingress/main.go
+++ b/cmd/ingress/main.go
@@ -19,11 +19,13 @@ package main
 import (
 	"os"
 
+	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/injection"
 	"knative.dev/pkg/injection/sharedmain"
 	"knative.dev/pkg/signals"
 
 	"knative.dev/eventing-natss/pkg/broker/ingress"
+	"knative.dev/eventing-natss/pkg/common/configloader/fsloader"
 )
 
 func main() {
@@ -31,6 +33,7 @@ func main() {
 
 	ctx := signals.NewContext()
 	ctx = sharedmain.WithHealthProbesDisabled(ctx)
+	ctx = fsloader.WithLoader(ctx, configmap.Load)
 
 	ns := os.Getenv("NAMESPACE")
 	if ns != "" {

--- a/config/broker/500-shared-ingress.yaml
+++ b/config/broker/500-shared-ingress.yaml
@@ -42,10 +42,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: NATS_URL
-              value: "nats://nats.nats-io.svc.cluster.local:4222"
             - name: PORT
               value: "8080"
+          volumeMounts:
+            - name: config-nats-broker
+              mountPath: /etc/config-nats-broker
+              readOnly: true
           ports:
             - containerPort: 8080
               name: http
@@ -81,6 +83,10 @@ spec:
                 - ALL
             seccompProfile:
               type: RuntimeDefault
+      volumes:
+        - name: config-nats-broker
+          configMap:
+            name: config-nats-broker
 ---
 apiVersion: v1
 kind: Service

--- a/pkg/broker/ingress/controller.go
+++ b/pkg/broker/ingress/controller.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
+	nats "github.com/nats-io/nats.go"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -58,31 +59,16 @@ type envConfig struct {
 func NewController(ctx context.Context, _ configmap.Watcher) *controller.Impl {
 	logger := logging.FromContext(ctx)
 
-	// Load environment configuration
-	env := &envConfig{}
-	if err := envconfig.Process("", env); err != nil {
+	env, err := loadEnvConfig()
+	if err != nil {
 		logger.Fatalw("Failed to process environment variables", zap.Error(err))
 	}
 
 	logger.Infow("Starting shared broker ingress", zap.Int("port", env.Port))
 
-	// Load NATS configuration from mounted ConfigMap
-	fsLoader, err := fsloader.Get(ctx)
+	natsConn, err := buildNatsConn(ctx)
 	if err != nil {
-		logger.Fatalw("Failed to get ConfigMap loader from context", zap.Error(err))
-	}
-	cmData, err := fsLoader(constants.SettingsConfigMapMountPath)
-	if err != nil {
-		logger.Fatalw("Failed to load NATS ConfigMap", zap.Error(err))
-	}
-	natsConfig, err := commonnats.LoadEventingNatsConfig(cmData)
-	if err != nil {
-		logger.Fatalw("Failed to parse NATS configuration", zap.Error(err))
-	}
-
-	natsConn, err := commonnats.NewNatsConn(ctx, natsConfig)
-	if err != nil {
-		logger.Fatalw("Failed to create NATS connection", zap.Error(err))
+		logger.Fatalw("Failed to initialize NATS connection", zap.Error(err))
 	}
 
 	// Create JetStream context
@@ -163,6 +149,29 @@ func NewController(ctx context.Context, _ configmap.Watcher) *controller.Impl {
 
 	logger.Info("Shared ingress controller initialized")
 	return impl
+}
+
+// loadEnvConfig reads environment variables into envConfig.
+func loadEnvConfig() (*envConfig, error) {
+	env := &envConfig{}
+	return env, envconfig.Process("", env)
+}
+
+// buildNatsConn loads NATS configuration from the mounted ConfigMap and creates a connection.
+func buildNatsConn(ctx context.Context) (*nats.Conn, error) {
+	fsLoader, err := fsloader.Get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ConfigMap loader from context: %w", err)
+	}
+	cmData, err := fsLoader(constants.SettingsConfigMapMountPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load NATS ConfigMap: %w", err)
+	}
+	natsConfig, err := commonnats.LoadEventingNatsConfig(cmData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse NATS configuration: %w", err)
+	}
+	return commonnats.NewNatsConn(ctx, natsConfig)
 }
 
 // filterContractConfigMap returns true if the object is the contract ConfigMap

--- a/pkg/broker/ingress/controller.go
+++ b/pkg/broker/ingress/controller.go
@@ -36,7 +36,9 @@ import (
 
 	configmapinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap"
 
+	"knative.dev/eventing-natss/pkg/broker/constants"
 	"knative.dev/eventing-natss/pkg/broker/contract"
+	"knative.dev/eventing-natss/pkg/common/configloader/fsloader"
 	commonnats "knative.dev/eventing-natss/pkg/common/nats"
 )
 
@@ -49,8 +51,7 @@ const (
 )
 
 type envConfig struct {
-	NatsURL string `envconfig:"NATS_URL" required:"true"`
-	Port    int    `envconfig:"PORT" default:"8080"`
+	Port int `envconfig:"PORT" default:"8080"`
 }
 
 // NewController creates a new shared ingress controller
@@ -63,13 +64,23 @@ func NewController(ctx context.Context, _ configmap.Watcher) *controller.Impl {
 		logger.Fatalw("Failed to process environment variables", zap.Error(err))
 	}
 
-	logger.Infow("Starting shared broker ingress",
-		zap.String("nats_url", env.NatsURL),
-		zap.Int("port", env.Port),
-	)
+	logger.Infow("Starting shared broker ingress", zap.Int("port", env.Port))
 
-	// Create NATS connection using URL from environment variable
-	natsConn, err := commonnats.NewNatsConnFromURL(ctx, env.NatsURL)
+	// Load NATS configuration from mounted ConfigMap
+	fsLoader, err := fsloader.Get(ctx)
+	if err != nil {
+		logger.Fatalw("Failed to get ConfigMap loader from context", zap.Error(err))
+	}
+	cmData, err := fsLoader(constants.SettingsConfigMapMountPath)
+	if err != nil {
+		logger.Fatalw("Failed to load NATS ConfigMap", zap.Error(err))
+	}
+	natsConfig, err := commonnats.LoadEventingNatsConfig(cmData)
+	if err != nil {
+		logger.Fatalw("Failed to parse NATS configuration", zap.Error(err))
+	}
+
+	natsConn, err := commonnats.NewNatsConn(ctx, natsConfig)
 	if err != nil {
 		logger.Fatalw("Failed to create NATS connection", zap.Error(err))
 	}

--- a/pkg/broker/ingress/controller_test.go
+++ b/pkg/broker/ingress/controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ingress
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -29,7 +30,11 @@ import (
 
 	"go.uber.org/zap"
 
+	"k8s.io/client-go/rest"
+	"knative.dev/pkg/injection"
+
 	"knative.dev/eventing-natss/pkg/broker/contract"
+	"knative.dev/eventing-natss/pkg/common/configloader/fsloader"
 )
 
 // fakeGetter is a test double for configMapGetter.
@@ -207,5 +212,101 @@ func TestLoadContractFromInformer_EmptyContract(t *testing.T) {
 
 	if got := h.GetBrokerCount(); got != 0 {
 		t.Errorf("broker count = %d, want 0 after loading empty contract", got)
+	}
+}
+
+// --- loadEnvConfig ---
+
+func TestLoadEnvConfig_Defaults(t *testing.T) {
+	env, err := loadEnvConfig()
+	if err != nil {
+		t.Fatalf("loadEnvConfig() unexpected error: %v", err)
+	}
+	if env.Port != 8080 {
+		t.Errorf("Port = %d, want 8080 (default)", env.Port)
+	}
+}
+
+func TestLoadEnvConfig_CustomPort(t *testing.T) {
+	t.Setenv("PORT", "9090")
+	env, err := loadEnvConfig()
+	if err != nil {
+		t.Fatalf("loadEnvConfig() unexpected error: %v", err)
+	}
+	if env.Port != 9090 {
+		t.Errorf("Port = %d, want 9090", env.Port)
+	}
+}
+
+func TestLoadEnvConfig_InvalidPort(t *testing.T) {
+	t.Setenv("PORT", "not-a-number")
+	_, err := loadEnvConfig()
+	if err == nil {
+		t.Error("loadEnvConfig() expected error for non-integer PORT, got nil")
+	}
+}
+
+// --- buildNatsConn ---
+
+func TestBuildNatsConn_NoLoaderInContext(t *testing.T) {
+	_, err := buildNatsConn(context.Background())
+	if err == nil {
+		t.Error("buildNatsConn() expected error when no loader in context, got nil")
+	}
+}
+
+func TestBuildNatsConn_LoaderReturnsError(t *testing.T) {
+	ctx := fsloader.WithLoader(context.Background(), func(_ string) (map[string]string, error) {
+		return nil, fmt.Errorf("disk read error")
+	})
+	_, err := buildNatsConn(ctx)
+	if err == nil {
+		t.Error("buildNatsConn() expected error when loader fails, got nil")
+	}
+}
+
+func TestBuildNatsConn_MissingNatsConfigKey(t *testing.T) {
+	// Loader returns a map without the required "eventing-nats" key.
+	ctx := fsloader.WithLoader(context.Background(), func(_ string) (map[string]string, error) {
+		return map[string]string{}, nil
+	})
+	_, err := buildNatsConn(ctx)
+	if err == nil {
+		t.Error("buildNatsConn() expected error for missing eventing-nats key, got nil")
+	}
+}
+
+func TestBuildNatsConn_InvalidNatsConfigYAML(t *testing.T) {
+	ctx := fsloader.WithLoader(context.Background(), func(_ string) (map[string]string, error) {
+		return map[string]string{"eventing-nats": "{"}, nil // invalid YAML
+	})
+	_, err := buildNatsConn(ctx)
+	if err == nil {
+		t.Error("buildNatsConn() expected error for invalid YAML, got nil")
+	}
+}
+
+func TestBuildNatsConn_ValidConfig(t *testing.T) {
+	t.Setenv("SYSTEM_NAMESPACE", "knative-eventing")
+	s := runBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	// NewNatsConn always creates a k8s secrets client (for credential/TLS resolution).
+	// Inject a stub rest.Config so it doesn't fall back to InClusterConfig.
+	ctx := injection.WithConfig(context.Background(), &rest.Config{Host: "http://localhost:6443"})
+	ctx = fsloader.WithLoader(ctx, func(_ string) (map[string]string, error) {
+		return map[string]string{
+			"eventing-nats": fmt.Sprintf("url: %s", s.ClientURL()),
+		}, nil
+	})
+
+	conn, err := buildNatsConn(ctx)
+	if err != nil {
+		t.Fatalf("buildNatsConn() unexpected error: %v", err)
+	}
+	defer conn.Close()
+
+	if !conn.IsConnected() {
+		t.Error("expected an active NATS connection")
 	}
 }

--- a/pkg/broker/ingress/controller_test.go
+++ b/pkg/broker/ingress/controller_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+
+	"go.uber.org/zap"
+
+	"knative.dev/eventing-natss/pkg/broker/contract"
+)
+
+// fakeGetter is a test double for configMapGetter.
+type fakeGetter struct {
+	cm  *corev1.ConfigMap
+	err error
+}
+
+func (f *fakeGetter) Get(_ string) (*corev1.ConfigMap, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.cm == nil {
+		return nil, apierrs.NewNotFound(schema.GroupResource{Resource: "configmaps"}, contract.ConfigMapName)
+	}
+	return f.cm, nil
+}
+
+// contractCM builds a ConfigMap whose data key holds the serialized contract.
+func contractCM(c *contract.Contract, namespace string) *corev1.ConfigMap {
+	raw, _ := json.Marshal(c)
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      contract.ConfigMapName,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			contract.ConfigMapDataKey: string(raw),
+		},
+	}
+}
+
+// nopHandler creates a Handler with a nil JetStream — safe for tests that
+// only exercise UpdateContract / GetBrokerCount (neither touches h.js).
+func nopHandler() *Handler {
+	return NewHandler(HandlerConfig{
+		Logger:    zap.NewNop().Sugar(),
+		JetStream: nil,
+	})
+}
+
+// --- filterContractConfigMap ---
+
+func TestFilterContractConfigMap_Nil(t *testing.T) {
+	if filterContractConfigMap(nil) {
+		t.Error("expected false for nil object")
+	}
+}
+
+func TestFilterContractConfigMap_WrongType(t *testing.T) {
+	if filterContractConfigMap("not a configmap") {
+		t.Error("expected false for non-ConfigMap type")
+	}
+}
+
+func TestFilterContractConfigMap_WrongName(t *testing.T) {
+	t.Setenv("SYSTEM_NAMESPACE", "knative-eventing")
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-configmap", Namespace: "knative-eventing"},
+	}
+	if filterContractConfigMap(cm) {
+		t.Error("expected false for wrong ConfigMap name")
+	}
+}
+
+func TestFilterContractConfigMap_WrongNamespace(t *testing.T) {
+	t.Setenv("SYSTEM_NAMESPACE", "knative-eventing")
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: contract.ConfigMapName, Namespace: "other-namespace"},
+	}
+	if filterContractConfigMap(cm) {
+		t.Error("expected false for wrong namespace")
+	}
+}
+
+func TestFilterContractConfigMap_Match(t *testing.T) {
+	t.Setenv("SYSTEM_NAMESPACE", "knative-eventing")
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: contract.ConfigMapName, Namespace: "knative-eventing"},
+	}
+	if !filterContractConfigMap(cm) {
+		t.Error("expected true for matching ConfigMap")
+	}
+}
+
+func TestFilterContractConfigMap_TombstoneMatch(t *testing.T) {
+	t.Setenv("SYSTEM_NAMESPACE", "knative-eventing")
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: contract.ConfigMapName, Namespace: "knative-eventing"},
+	}
+	tombstone := cache.DeletedFinalStateUnknown{Key: "knative-eventing/" + contract.ConfigMapName, Obj: cm}
+	if !filterContractConfigMap(tombstone) {
+		t.Error("expected true for tombstone wrapping matching ConfigMap")
+	}
+}
+
+func TestFilterContractConfigMap_TombstoneWrongName(t *testing.T) {
+	t.Setenv("SYSTEM_NAMESPACE", "knative-eventing")
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "wrong-name", Namespace: "knative-eventing"},
+	}
+	tombstone := cache.DeletedFinalStateUnknown{Key: "knative-eventing/wrong-name", Obj: cm}
+	if filterContractConfigMap(tombstone) {
+		t.Error("expected false for tombstone wrapping wrong-name ConfigMap")
+	}
+}
+
+// --- loadContractFromInformer ---
+
+func TestLoadContractFromInformer_NotFound(t *testing.T) {
+	h := nopHandler()
+	getter := &fakeGetter{} // returns NotFound
+	loadContractFromInformer(getter, h, zap.NewNop().Sugar())
+	if got := h.GetBrokerCount(); got != 0 {
+		t.Errorf("broker count = %d, want 0 (NotFound should be a no-op)", got)
+	}
+}
+
+func TestLoadContractFromInformer_GetterError(t *testing.T) {
+	h := nopHandler()
+	getter := &fakeGetter{err: fmt.Errorf("internal cache error")}
+	loadContractFromInformer(getter, h, zap.NewNop().Sugar())
+	if got := h.GetBrokerCount(); got != 0 {
+		t.Errorf("broker count = %d, want 0 (error should be a no-op)", got)
+	}
+}
+
+func TestLoadContractFromInformer_InvalidJSON(t *testing.T) {
+	t.Setenv("SYSTEM_NAMESPACE", "knative-eventing")
+	h := nopHandler()
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: contract.ConfigMapName, Namespace: "knative-eventing"},
+		Data:       map[string]string{contract.ConfigMapDataKey: "{invalid json}"},
+	}
+	getter := &fakeGetter{cm: cm}
+	loadContractFromInformer(getter, h, zap.NewNop().Sugar())
+	if got := h.GetBrokerCount(); got != 0 {
+		t.Errorf("broker count = %d, want 0 (bad JSON should be a no-op)", got)
+	}
+}
+
+func TestLoadContractFromInformer_ValidContract(t *testing.T) {
+	t.Setenv("SYSTEM_NAMESPACE", "knative-eventing")
+	h := nopHandler()
+
+	c := &contract.Contract{
+		Brokers: map[string]contract.BrokerContract{
+			"ns/br-a": {Namespace: "ns", Name: "br-a", Path: "/ns/br-a"},
+			"ns/br-b": {Namespace: "ns", Name: "br-b", Path: "/ns/br-b"},
+		},
+		Generation: 3,
+	}
+	getter := &fakeGetter{cm: contractCM(c, "knative-eventing")}
+	loadContractFromInformer(getter, h, zap.NewNop().Sugar())
+
+	if got := h.GetBrokerCount(); got != 2 {
+		t.Errorf("broker count = %d, want 2", got)
+	}
+}
+
+func TestLoadContractFromInformer_EmptyContract(t *testing.T) {
+	t.Setenv("SYSTEM_NAMESPACE", "knative-eventing")
+	h := nopHandler()
+
+	// Seed handler with existing brokers first.
+	h.UpdateContract(&contract.Contract{
+		Brokers: map[string]contract.BrokerContract{
+			"ns/old": {Namespace: "ns", Name: "old", Path: "/ns/old"},
+		},
+	})
+
+	// Load an empty contract — should clear the existing entries.
+	getter := &fakeGetter{cm: contractCM(&contract.Contract{Brokers: map[string]contract.BrokerContract{}}, "knative-eventing")}
+	loadContractFromInformer(getter, h, zap.NewNop().Sugar())
+
+	if got := h.GetBrokerCount(); got != 0 {
+		t.Errorf("broker count = %d, want 0 after loading empty contract", got)
+	}
+}


### PR DESCRIPTION
**Release Note**

```release-note
shared ingress uses `config-nats-broker`, the same CM as uses borker filter to connect to NATS
```
