### PR TITLE
improve pull comsumer controlling concurrency per trigger

### DIFF
--- a/docs/broker.md
+++ b/docs/broker.md
@@ -243,7 +243,7 @@ Slow triggers affect only their own semaphore — they cannot starve or delay ot
 | Slow Subscriber | 5–10 | 200ms | 2–5 | Rate-limited or expensive downstream |
 | Balanced (default) | 10 | 200ms | 20 | General purpose |
 
-`max-concurrency` should be ≥ `fetch-batch-size` so that a freshly-fetched batch always has available semaphore slots. If `max-concurrency` < `fetch-batch-size`, the later messages in a batch will sit fetched-but-unprocessed with their AckWait clocks ticking, potentially triggering early redeliveries.
+The fetch loop caps each pull request to the number of free semaphore slots, so a batch is never larger than the available dispatch capacity. This means `max-concurrency` and `fetch-batch-size` can be tuned independently — there is no requirement for one to be larger than the other.
 
 ## Architecture
 
@@ -301,7 +301,7 @@ After all retries are exhausted, if a dead letter sink is configured, the event 
 
 ### Duplicate message delivery
 
-If consumers are receiving the same event more than once, the most common cause is that `max-concurrency` is set lower than `fetch-batch-size`, causing later messages in a batch to hit their AckWait deadline before being dispatched. Ensure `max-concurrency` ≥ `fetch-batch-size`, or increase `trigger.spec.delivery.timeout`.
+If consumers are receiving the same event more than once, the most likely cause is that the subscriber is taking longer than `trigger.spec.delivery.timeout` (the consumer's AckWait) to respond. JetStream redelivers the message once AckWait expires. Increase the timeout or reduce subscriber latency.
 
 ### Events going to dead letter sink
 

--- a/docs/broker.md
+++ b/docs/broker.md
@@ -163,19 +163,20 @@ spec:
 
 ### Filter Environment Variables
 
-The filter component can be configured using environment variables:
+These variables set the **broker-wide defaults** for the filter deployment. All triggers in the same broker share these defaults unless they override them with per-trigger annotations (see below).
 
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `NATS_URL` | NATS server URL | Required |
 | `POD_NAME` | Pod name for identification | Required |
 | `CONTAINER_NAME` | Container name for identification | Required |
-| `CONSUMER_FETCH_BATCH_SIZE` | Number of messages to fetch per batch | 10 |
-| `CONSUMER_FETCH_TIMEOUT` | Timeout for fetch operations | 500ms |
+| `CONSUMER_FETCH_BATCH_SIZE` | Number of messages to fetch per batch | `10` |
+| `CONSUMER_FETCH_TIMEOUT` | How long a fetch waits for messages before returning empty | `200ms` |
+| `CONSUMER_MAX_CONCURRENCY` | Maximum concurrent in-flight HTTP dispatches per trigger | `20` |
 
 ### Configuring Consumer Fetch via Broker Annotation
 
-You can configure the consumer fetch settings per-broker using the broker annotation:
+Set broker-wide defaults for all triggers using the `natsjetstream.eventing.knative.dev/config` annotation. These are injected as environment variables into the filter deployment.
 
 ```yaml
 apiVersion: eventing.knative.dev/v1
@@ -190,49 +191,59 @@ metadata:
           "replicas": 2,
           "env": [
             {"name": "CONSUMER_FETCH_BATCH_SIZE", "value": "50"},
-            {"name": "CONSUMER_FETCH_TIMEOUT", "value": "1s"}
+            {"name": "CONSUMER_FETCH_TIMEOUT", "value": "1s"},
+            {"name": "CONSUMER_MAX_CONCURRENCY", "value": "40"}
           ]
         }
       }
 ```
 
-### Tuning Consumer Performance
+### Per-Trigger Configuration
 
-**High Throughput** - Increase batch size to fetch more messages per request:
+Each trigger can override the broker-wide defaults via annotations. This lets individual triggers with different throughput or latency requirements coexist in the same broker without affecting each other.
 
-```yaml
-natsjetstream.eventing.knative.dev/config: |
-  {
-    "filter": {
-      "env": [
-        {"name": "CONSUMER_FETCH_BATCH_SIZE", "value": "100"},
-        {"name": "CONSUMER_FETCH_TIMEOUT", "value": "2s"}
-      ]
-    }
-  }
-```
-
-**Low Latency** - Decrease batch size for immediate processing:
+| Annotation | Description | Default |
+|------------|-------------|---------|
+| `natsjetstream.eventing.knative.dev/fetch-batch-size` | Messages fetched per pull request | `CONSUMER_FETCH_BATCH_SIZE` |
+| `natsjetstream.eventing.knative.dev/fetch-timeout` | Wait time per fetch when no messages arrive (Go duration, e.g. `200ms`, `1s`) | `CONSUMER_FETCH_TIMEOUT` |
+| `natsjetstream.eventing.knative.dev/max-concurrency` | Maximum concurrent in-flight HTTP dispatches for this trigger | `CONSUMER_MAX_CONCURRENCY` |
 
 ```yaml
-natsjetstream.eventing.knative.dev/config: |
-  {
-    "filter": {
-      "env": [
-        {"name": "CONSUMER_FETCH_BATCH_SIZE", "value": "1"},
-        {"name": "CONSUMER_FETCH_TIMEOUT", "value": "100ms"}
-      ]
-    }
-  }
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: high-throughput-trigger
+  annotations:
+    natsjetstream.eventing.knative.dev/fetch-batch-size: "100"
+    natsjetstream.eventing.knative.dev/fetch-timeout: "1s"
+    natsjetstream.eventing.knative.dev/max-concurrency: "50"
+spec:
+  broker: my-broker
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: analytics-service
 ```
 
-**Tuning Guidelines:**
+### Backpressure and Concurrency Model
 
-| Scenario | Batch Size | Timeout | Use Case |
-|----------|------------|---------|----------|
-| High Throughput | 50-100 | 1-2s | Batch processing, analytics |
-| Low Latency | 1-5 | 100ms | Real-time notifications |
-| Balanced | 10-20 | 500ms | General purpose (default) |
+The filter dispatches messages concurrently using a per-trigger counting semaphore controlled by `max-concurrency`. The semaphore is acquired **before** fetching each message's dispatch goroutine, so when all slots are occupied the fetch loop stalls and new messages remain in the JetStream stream with their AckWait clocks not yet running. This prevents unbounded goroutine growth and avoids the AckWait expiry / duplicate-delivery problem that arises when messages are fetched faster than they can be processed.
+
+Each dispatched message also carries a context deadline equal to the consumer's `AckWait` (set via `trigger.spec.delivery.timeout`). If the subscriber does not respond within that window the HTTP call is cancelled and JetStream redelivers the message automatically.
+
+Slow triggers affect only their own semaphore — they cannot starve or delay other triggers sharing the same filter pod.
+
+### Tuning Guidelines
+
+| Scenario | Batch Size | Fetch Timeout | Max Concurrency | Use Case |
+|----------|------------|---------------|-----------------|----------|
+| High Throughput | 50–100 | 1–2s | 50–100 | Batch processing, analytics |
+| Low Latency | 1–5 | 100ms | 10–20 | Real-time notifications |
+| Slow Subscriber | 5–10 | 200ms | 2–5 | Rate-limited or expensive downstream |
+| Balanced (default) | 10 | 200ms | 20 | General purpose |
+
+`max-concurrency` should be ≥ `fetch-batch-size` so that a freshly-fetched batch always has available semaphore slots. If `max-concurrency` < `fetch-batch-size`, the later messages in a batch will sit fetched-but-unprocessed with their AckWait clocks ticking, potentially triggering early redeliveries.
 
 ## Architecture
 
@@ -282,10 +293,15 @@ After all retries are exhausted, if a dead letter sink is configured, the event 
 2. Verify the subscriber service is running and accessible
 3. Check filter pod logs: `kubectl logs -l app=natsjs-broker-filter`
 
-### High latency
+### High latency or low throughput
 
-1. Increase `CONSUMER_FETCH_BATCH_SIZE` for better throughput
-2. Check NATS server health and connection
+1. Increase `CONSUMER_FETCH_BATCH_SIZE` (or the trigger annotation) to fetch more messages per round-trip
+2. Increase `CONSUMER_MAX_CONCURRENCY` (or the trigger annotation) to allow more concurrent dispatches
+3. Check NATS server health and connection
+
+### Duplicate message delivery
+
+If consumers are receiving the same event more than once, the most common cause is that `max-concurrency` is set lower than `fetch-batch-size`, causing later messages in a batch to hit their AckWait deadline before being dispatched. Ensure `max-concurrency` ≥ `fetch-batch-size`, or increase `trigger.spec.delivery.timeout`.
 
 ### Events going to dead letter sink
 

--- a/pkg/broker/filter/consumer.go
+++ b/pkg/broker/filter/consumer.go
@@ -42,6 +42,11 @@ const (
 	DefaultFetchBatchSize = 10
 	// DefaultFetchTimeout is the default timeout for fetching messages
 	DefaultFetchTimeout = 200 * time.Millisecond
+	// DefaultMaxConcurrency is the default maximum number of messages dispatched concurrently
+	// across all trigger subscriptions in a ConsumerManager. Should be >= FetchBatchSize so a
+	// full batch always has available slots and is never left fetched-but-unprocessed with its
+	// AckWait ticking.
+	DefaultMaxConcurrency = 20
 )
 
 // ConsumerManagerConfig holds configuration for the ConsumerManager
@@ -53,6 +58,14 @@ type ConsumerManagerConfig struct {
 	// FetchTimeout is the timeout for fetching messages.
 	// Defaults to DefaultFetchTimeout if not set.
 	FetchTimeout time.Duration
+
+	// MaxConcurrency is the maximum number of messages that may be dispatched
+	// concurrently across all trigger subscriptions. The fetch loop acquires a
+	// semaphore slot before spawning each dispatch goroutine, so this directly
+	// bounds the number of in-flight HTTP calls and provides backpressure to
+	// the stream when all slots are busy.
+	// Defaults to DefaultMaxConcurrency if not set.
+	MaxConcurrency int
 }
 
 // ConsumerManager manages JetStream consumer subscriptions for triggers
@@ -66,6 +79,12 @@ type ConsumerManager struct {
 	// Configuration
 	fetchBatchSize int
 	fetchTimeout   time.Duration
+
+	// sem is a counting semaphore that limits concurrent in-flight dispatches.
+	// A slot is acquired before spawning each dispatch goroutine and released
+	// when the goroutine exits, providing backpressure to the fetch loop.
+	// nil when the manager is constructed directly (e.g. in tests).
+	sem chan struct{}
 
 	// Event dispatcher
 	dispatcher *kncloudevents.Dispatcher
@@ -82,6 +101,7 @@ type TriggerSubscription struct {
 	handler      *TriggerHandler
 	streamName   string
 	consumerName string
+	ackWait      time.Duration
 	cancel       context.CancelFunc
 }
 
@@ -94,6 +114,7 @@ func NewConsumerManager(ctx context.Context, conn *nats.Conn, js nats.JetStreamC
 	// Apply defaults
 	fetchBatchSize := DefaultFetchBatchSize
 	fetchTimeout := DefaultFetchTimeout
+	maxConcurrency := DefaultMaxConcurrency
 
 	if config != nil {
 		if config.FetchBatchSize > 0 {
@@ -101,6 +122,9 @@ func NewConsumerManager(ctx context.Context, conn *nats.Conn, js nats.JetStreamC
 		}
 		if config.FetchTimeout > 0 {
 			fetchTimeout = config.FetchTimeout
+		}
+		if config.MaxConcurrency > 0 {
+			maxConcurrency = config.MaxConcurrency
 		}
 	}
 
@@ -111,6 +135,7 @@ func NewConsumerManager(ctx context.Context, conn *nats.Conn, js nats.JetStreamC
 		conn:           conn,
 		fetchBatchSize: fetchBatchSize,
 		fetchTimeout:   fetchTimeout,
+		sem:            make(chan struct{}, maxConcurrency),
 		dispatcher:     dispatcher,
 		subscriptions:  make(map[string]*TriggerSubscription),
 	}
@@ -172,7 +197,7 @@ func (m *ConsumerManager) SubscribeTrigger(
 	consumerName := brokerutils.TriggerConsumerName(triggerUID)
 
 	// Get consumer info (also verifies consumer exists)
-	_, err = m.js.ConsumerInfo(streamName, consumerName)
+	consumerInfo, err := m.js.ConsumerInfo(streamName, consumerName)
 	if err != nil {
 		handler.Cleanup()
 		if errors.Is(err, nats.ErrConsumerNotFound) {
@@ -180,6 +205,7 @@ func (m *ConsumerManager) SubscribeTrigger(
 		}
 		return fmt.Errorf("failed to get consumer info: %w", err)
 	}
+	ackWait := consumerInfo.Config.AckWait
 
 	// Get the filter subject from the consumer's configuration
 	filterSubject := brokerutils.BrokerPublishSubjectName(broker.Namespace, broker.Name) + ".>"
@@ -214,23 +240,35 @@ func (m *ConsumerManager) SubscribeTrigger(
 		handler:      handler,
 		streamName:   streamName,
 		consumerName: consumerName,
+		ackWait:      ackWait,
 		cancel:       cancel,
 	}
 
 	// Start the message fetch loop
-	go m.fetchLoop(ctx, sub, handler, logger)
+	go m.fetchLoop(ctx, sub, handler, ackWait, logger)
 
 	logger.Infow("successfully started pull subscription for trigger consumer")
 	return nil
 }
 
-// fetchLoop continuously fetches messages from the pull consumer
+// fetchLoop continuously fetches messages from the pull consumer and dispatches
+// them concurrently. Each message gets its own goroutine, but a semaphore slot
+// must be acquired before the goroutine is spawned. This means the loop stalls
+// when all concurrency slots are occupied, providing backpressure back to the
+// JetStream stream (messages remain un-fetched and their AckWait clocks have
+// not started). Each dispatch goroutine wraps its work in a context deadline
+// equal to the consumer's AckWait so that a subscriber that takes longer than
+// AckWait is cancelled before JetStream redelivers the message.
 func (m *ConsumerManager) fetchLoop(
 	ctx context.Context,
 	sub *nats.Subscription,
 	handler *TriggerHandler,
+	ackWait time.Duration,
 	logger *zap.SugaredLogger,
 ) {
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -241,7 +279,6 @@ func (m *ConsumerManager) fetchLoop(
 			msgs, err := sub.Fetch(m.fetchBatchSize, nats.MaxWait(m.fetchTimeout))
 			if err != nil {
 				if errors.Is(err, nats.ErrTimeout) {
-					// No messages available, continue polling
 					continue
 				}
 				if errors.Is(err, nats.ErrConnectionClosed) || errors.Is(err, nats.ErrConsumerDeleted) || errors.Is(err, nats.ErrBadSubscription) {
@@ -252,14 +289,52 @@ func (m *ConsumerManager) fetchLoop(
 					return
 				}
 				logger.Errorw("error fetching messages", zap.Error(err))
-				// Back off on errors
 				time.Sleep(200 * time.Millisecond)
 				continue
 			}
 
-			// Process fetched messages
 			for _, msg := range msgs {
-				handler.HandleMessage(msg)
+				msg := msg
+
+				// Acquire a semaphore slot before spawning the goroutine.
+				// When the semaphore is full every slot is occupied by an
+				// in-flight dispatch, so blocking here prevents us from
+				// fetching the next batch until capacity is available.
+				// Messages that have not yet been fetched stay safely in the
+				// stream with their AckWait clocks not yet running.
+				if m.sem != nil {
+					select {
+					case m.sem <- struct{}{}:
+					case <-ctx.Done():
+						return
+					}
+				}
+
+				wg.Add(1)
+				go func() {
+					defer func() {
+						if m.sem != nil {
+							<-m.sem
+						}
+						wg.Done()
+					}()
+
+					// Bound dispatch duration to AckWait so we cancel the
+					// outbound HTTP call before JetStream redelivers the
+					// message. The context deadline starts here (after
+					// acquiring the slot) rather than at fetch time, keeping
+					// it aligned with when we actually begin dispatching.
+					var msgCtx context.Context
+					var cancel context.CancelFunc
+					if ackWait > 0 {
+						msgCtx, cancel = context.WithTimeout(ctx, ackWait)
+					} else {
+						msgCtx, cancel = context.WithCancel(ctx)
+					}
+					defer cancel()
+
+					handler.HandleMessage(msgCtx, msg)
+				}()
 			}
 		}
 	}

--- a/pkg/broker/filter/consumer.go
+++ b/pkg/broker/filter/consumer.go
@@ -119,12 +119,26 @@ type TriggerSubscription struct {
 	ackWait        time.Duration
 	fetchBatchSize int
 	fetchTimeout   time.Duration
+	maxConcurrency int
 	// sem is a per-trigger counting semaphore. A slot is acquired before
 	// spawning each dispatch goroutine and released when it exits, bounding
 	// the number of concurrent in-flight HTTP calls for this trigger and
-	// providing backpressure to its fetch loop.
-	sem    chan struct{}
+	// providing backpressure to its fetch loop. Replaced wholesale when
+	// max-concurrency changes; old in-flight goroutines keep releasing into
+	// the channel they captured.
+	sem chan struct{}
+	// dispatchCtx parents the per-message context used for each in-flight
+	// HTTP call. It lives for the subscription's full lifetime so that
+	// restarting the fetch loop on an annotation change does not cancel
+	// in-progress dispatches.
+	dispatchCtx    context.Context
+	dispatchCancel context.CancelFunc
+	// cancel stops the current fetch loop only. A new fetch loop with new
+	// parameters can be started after done closes.
 	cancel context.CancelFunc
+	// done is closed by the current fetch loop as soon as it returns, before
+	// it waits for its spawned dispatches to drain.
+	done chan struct{}
 }
 
 // NewConsumerManager creates a new consumer manager
@@ -224,7 +238,9 @@ func (m *ConsumerManager) SubscribeTrigger(
 	// Check if we already have a subscription for this trigger.
 	// All handler fields are safe to update in place — the NATS pull
 	// subscription is bound to (stream, consumer) which are derived from
-	// the immutable (broker, trigger UID) and never change.
+	// the immutable (broker, trigger UID) and never change. The fetch loop,
+	// however, captures its parameters at start, so a change to any of the
+	// three fetch-related annotations requires restarting it.
 	if existing, ok := m.subscriptions[triggerUID]; ok {
 		existing.handler.subscriber = subscriber
 		existing.handler.brokerIngressURL = brokerIngressURL
@@ -233,7 +249,47 @@ func (m *ConsumerManager) SubscribeTrigger(
 		existing.handler.filter = buildTriggerFilter(logger, trigger)
 		existing.handler.deadLetterSink = deadLetterSink
 		existing.handler.trigger = trigger
-		logger.Debugw("trigger subscription updated in place")
+
+		newBatch := parseTriggerAnnotationInt(trigger.Annotations, TriggerFetchBatchSizeAnnotation, m.fetchBatchSize, logger)
+		newTimeout := parseTriggerAnnotationDuration(trigger.Annotations, TriggerFetchTimeoutAnnotation, m.fetchTimeout, logger)
+		newMaxConc := parseTriggerAnnotationInt(trigger.Annotations, TriggerMaxConcurrencyAnnotation, m.defaultMaxConcurrency, logger)
+
+		if newBatch == existing.fetchBatchSize &&
+			newTimeout == existing.fetchTimeout &&
+			newMaxConc == existing.maxConcurrency {
+			logger.Debugw("trigger subscription updated in place")
+			return nil
+		}
+
+		logger.Infow("fetch parameters changed, restarting fetch loop",
+			zap.Int("old_batch_size", existing.fetchBatchSize),
+			zap.Int("new_batch_size", newBatch),
+			zap.Duration("old_fetch_timeout", existing.fetchTimeout),
+			zap.Duration("new_fetch_timeout", newTimeout),
+			zap.Int("old_max_concurrency", existing.maxConcurrency),
+			zap.Int("new_max_concurrency", newMaxConc),
+		)
+
+		// Stop the current fetch loop and wait until it has stopped calling
+		// Fetch. Two goroutines must not overlap on the same pull subscription.
+		// Worst-case wait is one fetchTimeout (the in-progress Fetch call
+		// returning). In-flight dispatches use existing.dispatchCtx and keep
+		// running uninterrupted.
+		existing.cancel()
+		<-existing.done
+
+		newSem := make(chan struct{}, newMaxConc)
+		fetchCtx, fetchCancel := context.WithCancel(m.ctx)
+		newDone := make(chan struct{})
+
+		existing.fetchBatchSize = newBatch
+		existing.fetchTimeout = newTimeout
+		existing.maxConcurrency = newMaxConc
+		existing.sem = newSem
+		existing.cancel = fetchCancel
+		existing.done = newDone
+
+		go m.fetchLoop(fetchCtx, existing.dispatchCtx, newDone, existing.subscription, existing.handler, existing.ackWait, newBatch, newTimeout, newSem, logger)
 		return nil
 	}
 
@@ -299,8 +355,11 @@ func (m *ConsumerManager) SubscribeTrigger(
 	// Set subscription and consumer info on handler
 	handler.subscription = sub
 
-	// Create cancellable context for the fetch loop
-	ctx, cancel := context.WithCancel(m.ctx)
+	// Two cancellable contexts: dispatchCtx survives fetch-loop restart and
+	// parents per-message msgCtx; fetchCtx controls the current fetch loop only.
+	dispatchCtx, dispatchCancel := context.WithCancel(m.ctx)
+	fetchCtx, fetchCancel := context.WithCancel(m.ctx)
+	done := make(chan struct{})
 
 	// Store the subscription
 	m.subscriptions[triggerUID] = &TriggerSubscription{
@@ -312,8 +371,12 @@ func (m *ConsumerManager) SubscribeTrigger(
 		ackWait:        ackWait,
 		fetchBatchSize: fetchBatchSize,
 		fetchTimeout:   fetchTimeout,
+		maxConcurrency: maxConcurrency,
 		sem:            sem,
-		cancel:         cancel,
+		dispatchCtx:    dispatchCtx,
+		dispatchCancel: dispatchCancel,
+		cancel:         fetchCancel,
+		done:           done,
 	}
 
 	logger.Infow("starting fetch loop",
@@ -323,7 +386,7 @@ func (m *ConsumerManager) SubscribeTrigger(
 	)
 
 	// Start the message fetch loop
-	go m.fetchLoop(ctx, sub, handler, ackWait, fetchBatchSize, fetchTimeout, sem, logger)
+	go m.fetchLoop(fetchCtx, dispatchCtx, done, sub, handler, ackWait, fetchBatchSize, fetchTimeout, sem, logger)
 
 	logger.Infow("successfully started pull subscription for trigger consumer")
 	return nil
@@ -338,8 +401,20 @@ func (m *ConsumerManager) SubscribeTrigger(
 // messages safely in the stream. Each dispatch goroutine carries a context
 // deadline equal to the consumer's AckWait so that the outbound HTTP call is
 // cancelled before JetStream redelivers the message.
+//
+// Two contexts govern lifetime:
+//   - ctx controls the fetch loop itself. Cancel it to stop fetching (used by
+//     unsubscribe and restart-on-annotation-change).
+//   - dispatchCtx parents each in-flight msgCtx. It survives a fetch-loop
+//     restart so a parameter change does not abort in-progress dispatches.
+//
+// done is closed before draining spawned dispatches, so a new fetch loop can
+// start as soon as the old one stops calling Fetch — without waiting for in-
+// flight HTTP calls to finish.
 func (m *ConsumerManager) fetchLoop(
 	ctx context.Context,
+	dispatchCtx context.Context,
+	done chan struct{},
 	sub *nats.Subscription,
 	handler *TriggerHandler,
 	ackWait time.Duration,
@@ -349,7 +424,11 @@ func (m *ConsumerManager) fetchLoop(
 	logger *zap.SugaredLogger,
 ) {
 	var wg sync.WaitGroup
+	// LIFO: close(done) runs first when this function returns, then wg.Wait
+	// drains spawned dispatches. The new fetch loop may start as soon as
+	// done closes; this goroutine lives on until its in-flight finish.
 	defer wg.Wait()
+	defer close(done)
 
 	for {
 		select {
@@ -428,9 +507,9 @@ func (m *ConsumerManager) fetchLoop(
 				var msgCtx context.Context
 				var cancel context.CancelFunc
 				if ackWait > 0 {
-					msgCtx, cancel = context.WithTimeout(ctx, ackWait)
+					msgCtx, cancel = context.WithTimeout(dispatchCtx, ackWait)
 				} else {
-					msgCtx, cancel = context.WithCancel(ctx)
+					msgCtx, cancel = context.WithCancel(dispatchCtx)
 				}
 				defer cancel()
 
@@ -462,9 +541,14 @@ func (m *ConsumerManager) unsubscribeLocked(triggerUID string) error {
 
 	logger.Infow("unsubscribing from trigger consumer")
 
-	// Cancel the fetch loop first
+	// Cancel the fetch loop and any in-flight dispatches. The two contexts
+	// are separate so restart-on-annotation-change can stop the fetch loop
+	// without aborting in-progress HTTP calls; on unsubscribe we cancel both.
 	if sub.cancel != nil {
 		sub.cancel()
+	}
+	if sub.dispatchCancel != nil {
+		sub.dispatchCancel()
 	}
 
 	// Unsubscribe from the pull consumer

--- a/pkg/broker/filter/consumer.go
+++ b/pkg/broker/filter/consumer.go
@@ -324,13 +324,14 @@ func (m *ConsumerManager) SubscribeTrigger(
 }
 
 // fetchLoop continuously fetches messages from the pull consumer and dispatches
-// them concurrently. Each message gets its own goroutine, but a semaphore slot
-// must be acquired before the goroutine is spawned. This means the loop stalls
-// when all concurrency slots are occupied, providing backpressure back to the
-// JetStream stream (messages remain un-fetched and their AckWait clocks have
-// not started). Each dispatch goroutine wraps its work in a context deadline
-// equal to the consumer's AckWait so that a subscriber that takes longer than
-// AckWait is cancelled before JetStream redelivers the message.
+// them concurrently. Before each fetch it checks how many semaphore slots are
+// free and requests at most that many messages. This guarantees every fetched
+// message acquires its slot within microseconds — no message sits fetched-but-
+// unprocessed with JetStream's AckWait clock already running. When all slots
+// are occupied the loop waits one fetchTimeout before re-checking, leaving
+// messages safely in the stream. Each dispatch goroutine carries a context
+// deadline equal to the consumer's AckWait so that the outbound HTTP call is
+// cancelled before JetStream redelivers the message.
 func (m *ConsumerManager) fetchLoop(
 	ctx context.Context,
 	sub *nats.Subscription,
@@ -350,67 +351,85 @@ func (m *ConsumerManager) fetchLoop(
 			logger.Debugw("fetch loop stopped")
 			return
 		default:
-			// Fetch a batch of messages
-			msgs, err := sub.Fetch(fetchBatchSize, nats.MaxWait(fetchTimeout))
-			if err != nil {
-				if errors.Is(err, nats.ErrTimeout) {
-					continue
-				}
-				if errors.Is(err, nats.ErrConnectionClosed) || errors.Is(err, nats.ErrConsumerDeleted) || errors.Is(err, nats.ErrBadSubscription) {
-					logger.Warnw("subscription closed, stopping fetch loop", zap.Error(err))
+		}
+
+		// Determine how many messages to request this round.
+		// When a semaphore is configured, cap the request to the number of
+		// free slots so every returned message can acquire its slot
+		// immediately — keeping our AckWait context aligned with JetStream's
+		// delivery clock. fetchLoop is the only goroutine that acquires slots,
+		// so cap(sem)-len(sem) is a stable lower bound: in-flight goroutines
+		// can only release slots between here and the acquire, never consume
+		// new ones.
+		batchSize := fetchBatchSize
+		if sem != nil {
+			available := cap(sem) - len(sem)
+			if available == 0 {
+				// All slots occupied. Wait one fetch interval so messages
+				// remain in the stream, then re-check.
+				select {
+				case <-time.After(fetchTimeout):
+				case <-ctx.Done():
 					return
 				}
-				if errors.Is(err, context.Canceled) {
-					return
-				}
-				logger.Errorw("error fetching messages", zap.Error(err))
-				time.Sleep(200 * time.Millisecond)
 				continue
 			}
-
-			for _, msg := range msgs {
-				msg := msg
-
-				// Acquire a per-trigger semaphore slot before spawning the
-				// goroutine. When the semaphore is full every slot is occupied
-				// by an in-flight dispatch for this trigger, so blocking here
-				// prevents fetching the next batch until capacity is available.
-				// Messages that have not yet been fetched stay safely in the
-				// stream with their AckWait clocks not yet running.
-				if sem != nil {
-					select {
-					case sem <- struct{}{}:
-					case <-ctx.Done():
-						return
-					}
-				}
-
-				wg.Add(1)
-				go func() {
-					defer func() {
-						if sem != nil {
-							<-sem
-						}
-						wg.Done()
-					}()
-
-					// Bound dispatch duration to AckWait so we cancel the
-					// outbound HTTP call before JetStream redelivers the
-					// message. The context deadline starts here (after
-					// acquiring the slot) rather than at fetch time, keeping
-					// it aligned with when we actually begin dispatching.
-					var msgCtx context.Context
-					var cancel context.CancelFunc
-					if ackWait > 0 {
-						msgCtx, cancel = context.WithTimeout(ctx, ackWait)
-					} else {
-						msgCtx, cancel = context.WithCancel(ctx)
-					}
-					defer cancel()
-
-					handler.HandleMessage(msgCtx, msg)
-				}()
+			if available < batchSize {
+				batchSize = available
 			}
+		}
+
+		msgs, err := sub.Fetch(batchSize, nats.MaxWait(fetchTimeout))
+		if err != nil {
+			if errors.Is(err, nats.ErrTimeout) {
+				continue
+			}
+			if errors.Is(err, nats.ErrConnectionClosed) || errors.Is(err, nats.ErrConsumerDeleted) || errors.Is(err, nats.ErrBadSubscription) {
+				logger.Warnw("subscription closed, stopping fetch loop", zap.Error(err))
+				return
+			}
+			if errors.Is(err, context.Canceled) {
+				return
+			}
+			logger.Errorw("error fetching messages", zap.Error(err))
+			time.Sleep(200 * time.Millisecond)
+			continue
+		}
+
+		for _, msg := range msgs {
+			msg := msg
+
+			// Acquire a semaphore slot. Because batchSize was capped to the
+			// number of free slots above, this send is non-blocking in the
+			// steady state. The ctx.Done case handles clean shutdown.
+			if sem != nil {
+				select {
+				case sem <- struct{}{}:
+				case <-ctx.Done():
+					return
+				}
+			}
+
+			wg.Add(1)
+			go func() {
+				defer func() {
+					if sem != nil {
+						<-sem
+					}
+					wg.Done()
+				}()
+
+				var msgCtx context.Context
+				var cancel context.CancelFunc
+				if ackWait > 0 {
+					msgCtx, cancel = context.WithTimeout(ctx, ackWait)
+				} else {
+					msgCtx, cancel = context.WithCancel(ctx)
+				}
+				defer cancel()
+
+				handler.HandleMessage(msgCtx, msg)
+			}()
 		}
 	}
 }

--- a/pkg/broker/filter/consumer.go
+++ b/pkg/broker/filter/consumer.go
@@ -163,6 +163,44 @@ func NewConsumerManager(ctx context.Context, conn *nats.Conn, js nats.JetStreamC
 	}
 }
 
+// parseTriggerAnnotationInt reads key from annotations as a positive int,
+// returning defaultVal (with a warning log) when absent, non-numeric, or <= 0.
+func parseTriggerAnnotationInt(annotations map[string]string, key string, defaultVal int, logger *zap.SugaredLogger) int {
+	ann := annotations[key]
+	if ann == "" {
+		return defaultVal
+	}
+	n, err := strconv.Atoi(ann)
+	if err != nil || n <= 0 {
+		logger.Warnw("invalid annotation value, using default",
+			zap.String("key", key),
+			zap.String("annotation", ann),
+			zap.Int("default", defaultVal),
+		)
+		return defaultVal
+	}
+	return n
+}
+
+// parseTriggerAnnotationDuration reads key from annotations as a positive
+// duration, returning defaultVal (with a warning log) when absent, unparseable, or <= 0.
+func parseTriggerAnnotationDuration(annotations map[string]string, key string, defaultVal time.Duration, logger *zap.SugaredLogger) time.Duration {
+	ann := annotations[key]
+	if ann == "" {
+		return defaultVal
+	}
+	d, err := time.ParseDuration(ann)
+	if err != nil || d <= 0 {
+		logger.Warnw("invalid annotation value, using default",
+			zap.String("key", key),
+			zap.String("annotation", ann),
+			zap.Duration("default", defaultVal),
+		)
+		return defaultVal
+	}
+	return d
+}
+
 // SubscribeTrigger creates a pull-based subscription for a trigger's consumer
 func (m *ConsumerManager) SubscribeTrigger(
 	trigger *eventingv1.Trigger,
@@ -232,41 +270,9 @@ func (m *ConsumerManager) SubscribeTrigger(
 	// Resolve per-trigger fetch parameters.
 	// Trigger annotations take precedence; absent or invalid values fall back
 	// to the manager defaults set via env vars on the filter deployment.
-	fetchBatchSize := m.fetchBatchSize
-	if ann := trigger.Annotations[TriggerFetchBatchSizeAnnotation]; ann != "" {
-		if n, err := strconv.Atoi(ann); err == nil && n > 0 {
-			fetchBatchSize = n
-		} else {
-			logger.Warnw("invalid fetch-batch-size annotation, using default",
-				zap.String("annotation", ann),
-				zap.Int("default", fetchBatchSize),
-			)
-		}
-	}
-
-	fetchTimeout := m.fetchTimeout
-	if ann := trigger.Annotations[TriggerFetchTimeoutAnnotation]; ann != "" {
-		if d, err := time.ParseDuration(ann); err == nil && d > 0 {
-			fetchTimeout = d
-		} else {
-			logger.Warnw("invalid fetch-timeout annotation, using default",
-				zap.String("annotation", ann),
-				zap.Duration("default", fetchTimeout),
-			)
-		}
-	}
-
-	maxConcurrency := m.defaultMaxConcurrency
-	if ann := trigger.Annotations[TriggerMaxConcurrencyAnnotation]; ann != "" {
-		if n, err := strconv.Atoi(ann); err == nil && n > 0 {
-			maxConcurrency = n
-		} else {
-			logger.Warnw("invalid max-concurrency annotation, using default",
-				zap.String("annotation", ann),
-				zap.Int("default", maxConcurrency),
-			)
-		}
-	}
+	fetchBatchSize := parseTriggerAnnotationInt(trigger.Annotations, TriggerFetchBatchSizeAnnotation, m.fetchBatchSize, logger)
+	fetchTimeout := parseTriggerAnnotationDuration(trigger.Annotations, TriggerFetchTimeoutAnnotation, m.fetchTimeout, logger)
+	maxConcurrency := parseTriggerAnnotationInt(trigger.Annotations, TriggerMaxConcurrencyAnnotation, m.defaultMaxConcurrency, logger)
 
 	sem := make(chan struct{}, maxConcurrency)
 

--- a/pkg/broker/filter/consumer.go
+++ b/pkg/broker/filter/consumer.go
@@ -55,6 +55,20 @@ const (
 	// integer; absent or invalid values fall back to DefaultMaxConcurrency (or
 	// the value set via CONSUMER_MAX_CONCURRENCY on the filter deployment).
 	TriggerMaxConcurrencyAnnotation = "natsjetstream.eventing.knative.dev/max-concurrency"
+
+	// TriggerFetchBatchSizeAnnotation is the annotation key on a Trigger that
+	// overrides the number of messages fetched from JetStream in each pull
+	// request. Must be a positive integer; absent or invalid values fall back
+	// to DefaultFetchBatchSize (or CONSUMER_FETCH_BATCH_SIZE on the filter
+	// deployment).
+	TriggerFetchBatchSizeAnnotation = "natsjetstream.eventing.knative.dev/fetch-batch-size"
+
+	// TriggerFetchTimeoutAnnotation is the annotation key on a Trigger that
+	// overrides how long a fetch request waits for messages before returning
+	// empty. Must be a valid Go duration string (e.g. "500ms", "1s"); absent
+	// or invalid values fall back to DefaultFetchTimeout (or
+	// CONSUMER_FETCH_TIMEOUT on the filter deployment).
+	TriggerFetchTimeoutAnnotation = "natsjetstream.eventing.knative.dev/fetch-timeout"
 )
 
 // ConsumerManagerConfig holds configuration for the ConsumerManager
@@ -103,6 +117,8 @@ type TriggerSubscription struct {
 	streamName   string
 	consumerName string
 	ackWait      time.Duration
+	fetchBatchSize int
+	fetchTimeout   time.Duration
 	// sem is a per-trigger counting semaphore. A slot is acquired before
 	// spawning each dispatch goroutine and released when it exits, bounding
 	// the number of concurrent in-flight HTTP calls for this trigger and
@@ -213,9 +229,33 @@ func (m *ConsumerManager) SubscribeTrigger(
 	}
 	ackWait := consumerInfo.Config.AckWait
 
-	// Determine per-trigger concurrency limit.
-	// The trigger annotation takes precedence; falls back to the manager default
-	// which comes from CONSUMER_MAX_CONCURRENCY on the filter deployment.
+	// Resolve per-trigger fetch parameters.
+	// Trigger annotations take precedence; absent or invalid values fall back
+	// to the manager defaults set via env vars on the filter deployment.
+	fetchBatchSize := m.fetchBatchSize
+	if ann := trigger.Annotations[TriggerFetchBatchSizeAnnotation]; ann != "" {
+		if n, err := strconv.Atoi(ann); err == nil && n > 0 {
+			fetchBatchSize = n
+		} else {
+			logger.Warnw("invalid fetch-batch-size annotation, using default",
+				zap.String("annotation", ann),
+				zap.Int("default", fetchBatchSize),
+			)
+		}
+	}
+
+	fetchTimeout := m.fetchTimeout
+	if ann := trigger.Annotations[TriggerFetchTimeoutAnnotation]; ann != "" {
+		if d, err := time.ParseDuration(ann); err == nil && d > 0 {
+			fetchTimeout = d
+		} else {
+			logger.Warnw("invalid fetch-timeout annotation, using default",
+				zap.String("annotation", ann),
+				zap.Duration("default", fetchTimeout),
+			)
+		}
+	}
+
 	maxConcurrency := m.defaultMaxConcurrency
 	if ann := trigger.Annotations[TriggerMaxConcurrencyAnnotation]; ann != "" {
 		if n, err := strconv.Atoi(ann); err == nil && n > 0 {
@@ -258,22 +298,26 @@ func (m *ConsumerManager) SubscribeTrigger(
 
 	// Store the subscription
 	m.subscriptions[triggerUID] = &TriggerSubscription{
-		trigger:      trigger,
-		subscription: sub,
-		handler:      handler,
-		streamName:   streamName,
-		consumerName: consumerName,
-		ackWait:      ackWait,
-		sem:          sem,
-		cancel:       cancel,
+		trigger:        trigger,
+		subscription:   sub,
+		handler:        handler,
+		streamName:     streamName,
+		consumerName:   consumerName,
+		ackWait:        ackWait,
+		fetchBatchSize: fetchBatchSize,
+		fetchTimeout:   fetchTimeout,
+		sem:            sem,
+		cancel:         cancel,
 	}
 
 	logger.Infow("starting fetch loop",
+		zap.Int("fetch_batch_size", fetchBatchSize),
+		zap.Duration("fetch_timeout", fetchTimeout),
 		zap.Int("max_concurrency", maxConcurrency),
 	)
 
 	// Start the message fetch loop
-	go m.fetchLoop(ctx, sub, handler, ackWait, sem, logger)
+	go m.fetchLoop(ctx, sub, handler, ackWait, fetchBatchSize, fetchTimeout, sem, logger)
 
 	logger.Infow("successfully started pull subscription for trigger consumer")
 	return nil
@@ -292,6 +336,8 @@ func (m *ConsumerManager) fetchLoop(
 	sub *nats.Subscription,
 	handler *TriggerHandler,
 	ackWait time.Duration,
+	fetchBatchSize int,
+	fetchTimeout time.Duration,
 	sem chan struct{},
 	logger *zap.SugaredLogger,
 ) {
@@ -305,7 +351,7 @@ func (m *ConsumerManager) fetchLoop(
 			return
 		default:
 			// Fetch a batch of messages
-			msgs, err := sub.Fetch(m.fetchBatchSize, nats.MaxWait(m.fetchTimeout))
+			msgs, err := sub.Fetch(fetchBatchSize, nats.MaxWait(fetchTimeout))
 			if err != nil {
 				if errors.Is(err, nats.ErrTimeout) {
 					continue

--- a/pkg/broker/filter/consumer.go
+++ b/pkg/broker/filter/consumer.go
@@ -111,12 +111,12 @@ type ConsumerManager struct {
 
 // TriggerSubscription holds the subscription and handler for a trigger
 type TriggerSubscription struct {
-	trigger      *eventingv1.Trigger
-	subscription *nats.Subscription
-	handler      *TriggerHandler
-	streamName   string
-	consumerName string
-	ackWait      time.Duration
+	trigger        *eventingv1.Trigger
+	subscription   *nats.Subscription
+	handler        *TriggerHandler
+	streamName     string
+	consumerName   string
+	ackWait        time.Duration
 	fetchBatchSize int
 	fetchTimeout   time.Duration
 	// sem is a per-trigger counting semaphore. A slot is acquired before

--- a/pkg/broker/filter/consumer.go
+++ b/pkg/broker/filter/consumer.go
@@ -136,9 +136,15 @@ type TriggerSubscription struct {
 	// cancel stops the current fetch loop only. A new fetch loop with new
 	// parameters can be started after done closes.
 	cancel context.CancelFunc
-	// done is closed by the current fetch loop as soon as it returns, before
-	// it waits for its spawned dispatches to drain.
+	// done is closed by the current fetch loop as soon as it returns.
+	// Restart waits on this before starting a new fetch loop on the same
+	// pull subscription.
 	done chan struct{}
+	// inflight tracks every dispatch goroutine spawned by any fetch loop
+	// for this subscription. unsubscribeLocked waits on it so the NATS
+	// subscription and trigger handler are not torn down while a dispatch
+	// goroutine is still using them (msg.Ack, h.filter.Filter, etc.).
+	inflight sync.WaitGroup
 }
 
 // NewConsumerManager creates a new consumer manager
@@ -289,7 +295,7 @@ func (m *ConsumerManager) SubscribeTrigger(
 		existing.cancel = fetchCancel
 		existing.done = newDone
 
-		go m.fetchLoop(fetchCtx, existing.dispatchCtx, newDone, existing.subscription, existing.handler, existing.ackWait, newBatch, newTimeout, newSem, logger)
+		go m.fetchLoop(fetchCtx, existing.dispatchCtx, newDone, &existing.inflight, existing.subscription, existing.handler, existing.ackWait, newBatch, newTimeout, newSem, logger)
 		return nil
 	}
 
@@ -362,7 +368,7 @@ func (m *ConsumerManager) SubscribeTrigger(
 	done := make(chan struct{})
 
 	// Store the subscription
-	m.subscriptions[triggerUID] = &TriggerSubscription{
+	ts := &TriggerSubscription{
 		trigger:        trigger,
 		subscription:   sub,
 		handler:        handler,
@@ -378,6 +384,7 @@ func (m *ConsumerManager) SubscribeTrigger(
 		cancel:         fetchCancel,
 		done:           done,
 	}
+	m.subscriptions[triggerUID] = ts
 
 	logger.Infow("starting fetch loop",
 		zap.Int("fetch_batch_size", fetchBatchSize),
@@ -386,7 +393,7 @@ func (m *ConsumerManager) SubscribeTrigger(
 	)
 
 	// Start the message fetch loop
-	go m.fetchLoop(fetchCtx, dispatchCtx, done, sub, handler, ackWait, fetchBatchSize, fetchTimeout, sem, logger)
+	go m.fetchLoop(fetchCtx, dispatchCtx, done, &ts.inflight, sub, handler, ackWait, fetchBatchSize, fetchTimeout, sem, logger)
 
 	logger.Infow("successfully started pull subscription for trigger consumer")
 	return nil
@@ -408,13 +415,17 @@ func (m *ConsumerManager) SubscribeTrigger(
 //   - dispatchCtx parents each in-flight msgCtx. It survives a fetch-loop
 //     restart so a parameter change does not abort in-progress dispatches.
 //
-// done is closed before draining spawned dispatches, so a new fetch loop can
-// start as soon as the old one stops calling Fetch — without waiting for in-
-// flight HTTP calls to finish.
+// Spawned dispatches are tracked on the subscription-scoped inflight
+// WaitGroup, not a local one. unsubscribeLocked waits on it to drain in-flight
+// dispatches (across any fetch-loop generation) before tearing down the NATS
+// subscription and trigger handler. The fetch loop itself does not wait on
+// dispatches — it closes done and returns as soon as it stops calling Fetch,
+// so a restart can start a new fetch loop without delay.
 func (m *ConsumerManager) fetchLoop(
 	ctx context.Context,
 	dispatchCtx context.Context,
 	done chan struct{},
+	inflight *sync.WaitGroup,
 	sub *nats.Subscription,
 	handler *TriggerHandler,
 	ackWait time.Duration,
@@ -423,11 +434,6 @@ func (m *ConsumerManager) fetchLoop(
 	sem chan struct{},
 	logger *zap.SugaredLogger,
 ) {
-	var wg sync.WaitGroup
-	// LIFO: close(done) runs first when this function returns, then wg.Wait
-	// drains spawned dispatches. The new fetch loop may start as soon as
-	// done closes; this goroutine lives on until its in-flight finish.
-	defer wg.Wait()
 	defer close(done)
 
 	for {
@@ -495,13 +501,13 @@ func (m *ConsumerManager) fetchLoop(
 				}
 			}
 
-			wg.Add(1)
+			inflight.Add(1)
 			go func() {
 				defer func() {
 					if sem != nil {
 						<-sem
 					}
-					wg.Done()
+					inflight.Done()
 				}()
 
 				var msgCtx context.Context
@@ -550,6 +556,14 @@ func (m *ConsumerManager) unsubscribeLocked(triggerUID string) error {
 	if sub.dispatchCancel != nil {
 		sub.dispatchCancel()
 	}
+
+	// Wait for every dispatch goroutine — across any fetch-loop generation —
+	// to exit before tearing down the NATS subscription and trigger handler.
+	// Without this wait, in-flight goroutines could race with Unsubscribe
+	// (msg.Ack on a closed subscription) and with handler.Cleanup (concurrent
+	// h.filter.Filter vs h.filter.Cleanup). Bounded by ackWait via msgCtx;
+	// resolves in milliseconds when the HTTP client respects ctx cancellation.
+	sub.inflight.Wait()
 
 	// Unsubscribe from the pull consumer
 	if err := sub.subscription.Unsubscribe(); err != nil {

--- a/pkg/broker/filter/consumer.go
+++ b/pkg/broker/filter/consumer.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
@@ -42,11 +43,18 @@ const (
 	DefaultFetchBatchSize = 10
 	// DefaultFetchTimeout is the default timeout for fetching messages
 	DefaultFetchTimeout = 200 * time.Millisecond
-	// DefaultMaxConcurrency is the default maximum number of messages dispatched concurrently
-	// across all trigger subscriptions in a ConsumerManager. Should be >= FetchBatchSize so a
-	// full batch always has available slots and is never left fetched-but-unprocessed with its
-	// AckWait ticking.
+	// DefaultMaxConcurrency is the default per-trigger maximum number of messages
+	// dispatched concurrently. Should be >= FetchBatchSize so a full batch always
+	// has available slots and is never left fetched-but-unprocessed with its
+	// AckWait ticking. Individual triggers can override this via the
+	// TriggerMaxConcurrencyAnnotation annotation.
 	DefaultMaxConcurrency = 20
+
+	// TriggerMaxConcurrencyAnnotation is the annotation key on a Trigger that
+	// overrides the per-trigger dispatch concurrency limit. Must be a positive
+	// integer; absent or invalid values fall back to DefaultMaxConcurrency (or
+	// the value set via CONSUMER_MAX_CONCURRENCY on the filter deployment).
+	TriggerMaxConcurrencyAnnotation = "natsjetstream.eventing.knative.dev/max-concurrency"
 )
 
 // ConsumerManagerConfig holds configuration for the ConsumerManager
@@ -59,11 +67,9 @@ type ConsumerManagerConfig struct {
 	// Defaults to DefaultFetchTimeout if not set.
 	FetchTimeout time.Duration
 
-	// MaxConcurrency is the maximum number of messages that may be dispatched
-	// concurrently across all trigger subscriptions. The fetch loop acquires a
-	// semaphore slot before spawning each dispatch goroutine, so this directly
-	// bounds the number of in-flight HTTP calls and provides backpressure to
-	// the stream when all slots are busy.
+	// MaxConcurrency is the default per-trigger maximum number of messages
+	// dispatched concurrently. Individual triggers can override this via the
+	// TriggerMaxConcurrencyAnnotation annotation.
 	// Defaults to DefaultMaxConcurrency if not set.
 	MaxConcurrency int
 }
@@ -77,14 +83,9 @@ type ConsumerManager struct {
 	conn *nats.Conn
 
 	// Configuration
-	fetchBatchSize int
-	fetchTimeout   time.Duration
-
-	// sem is a counting semaphore that limits concurrent in-flight dispatches.
-	// A slot is acquired before spawning each dispatch goroutine and released
-	// when the goroutine exits, providing backpressure to the fetch loop.
-	// nil when the manager is constructed directly (e.g. in tests).
-	sem chan struct{}
+	fetchBatchSize        int
+	fetchTimeout          time.Duration
+	defaultMaxConcurrency int
 
 	// Event dispatcher
 	dispatcher *kncloudevents.Dispatcher
@@ -102,7 +103,12 @@ type TriggerSubscription struct {
 	streamName   string
 	consumerName string
 	ackWait      time.Duration
-	cancel       context.CancelFunc
+	// sem is a per-trigger counting semaphore. A slot is acquired before
+	// spawning each dispatch goroutine and released when it exits, bounding
+	// the number of concurrent in-flight HTTP calls for this trigger and
+	// providing backpressure to its fetch loop.
+	sem    chan struct{}
+	cancel context.CancelFunc
 }
 
 // NewConsumerManager creates a new consumer manager
@@ -129,15 +135,15 @@ func NewConsumerManager(ctx context.Context, conn *nats.Conn, js nats.JetStreamC
 	}
 
 	return &ConsumerManager{
-		logger:         logging.FromContext(ctx),
-		ctx:            ctx,
-		js:             js,
-		conn:           conn,
-		fetchBatchSize: fetchBatchSize,
-		fetchTimeout:   fetchTimeout,
-		sem:            make(chan struct{}, maxConcurrency),
-		dispatcher:     dispatcher,
-		subscriptions:  make(map[string]*TriggerSubscription),
+		logger:                logging.FromContext(ctx),
+		ctx:                   ctx,
+		js:                    js,
+		conn:                  conn,
+		fetchBatchSize:        fetchBatchSize,
+		fetchTimeout:          fetchTimeout,
+		defaultMaxConcurrency: maxConcurrency,
+		dispatcher:            dispatcher,
+		subscriptions:         make(map[string]*TriggerSubscription),
 	}
 }
 
@@ -207,6 +213,23 @@ func (m *ConsumerManager) SubscribeTrigger(
 	}
 	ackWait := consumerInfo.Config.AckWait
 
+	// Determine per-trigger concurrency limit.
+	// The trigger annotation takes precedence; falls back to the manager default
+	// which comes from CONSUMER_MAX_CONCURRENCY on the filter deployment.
+	maxConcurrency := m.defaultMaxConcurrency
+	if ann := trigger.Annotations[TriggerMaxConcurrencyAnnotation]; ann != "" {
+		if n, err := strconv.Atoi(ann); err == nil && n > 0 {
+			maxConcurrency = n
+		} else {
+			logger.Warnw("invalid max-concurrency annotation, using default",
+				zap.String("annotation", ann),
+				zap.Int("default", maxConcurrency),
+			)
+		}
+	}
+
+	sem := make(chan struct{}, maxConcurrency)
+
 	// Get the filter subject from the consumer's configuration
 	filterSubject := brokerutils.BrokerPublishSubjectName(broker.Namespace, broker.Name) + ".>"
 
@@ -241,11 +264,16 @@ func (m *ConsumerManager) SubscribeTrigger(
 		streamName:   streamName,
 		consumerName: consumerName,
 		ackWait:      ackWait,
+		sem:          sem,
 		cancel:       cancel,
 	}
 
+	logger.Infow("starting fetch loop",
+		zap.Int("max_concurrency", maxConcurrency),
+	)
+
 	// Start the message fetch loop
-	go m.fetchLoop(ctx, sub, handler, ackWait, logger)
+	go m.fetchLoop(ctx, sub, handler, ackWait, sem, logger)
 
 	logger.Infow("successfully started pull subscription for trigger consumer")
 	return nil
@@ -264,6 +292,7 @@ func (m *ConsumerManager) fetchLoop(
 	sub *nats.Subscription,
 	handler *TriggerHandler,
 	ackWait time.Duration,
+	sem chan struct{},
 	logger *zap.SugaredLogger,
 ) {
 	var wg sync.WaitGroup
@@ -296,15 +325,15 @@ func (m *ConsumerManager) fetchLoop(
 			for _, msg := range msgs {
 				msg := msg
 
-				// Acquire a semaphore slot before spawning the goroutine.
-				// When the semaphore is full every slot is occupied by an
-				// in-flight dispatch, so blocking here prevents us from
-				// fetching the next batch until capacity is available.
+				// Acquire a per-trigger semaphore slot before spawning the
+				// goroutine. When the semaphore is full every slot is occupied
+				// by an in-flight dispatch for this trigger, so blocking here
+				// prevents fetching the next batch until capacity is available.
 				// Messages that have not yet been fetched stay safely in the
 				// stream with their AckWait clocks not yet running.
-				if m.sem != nil {
+				if sem != nil {
 					select {
-					case m.sem <- struct{}{}:
+					case sem <- struct{}{}:
 					case <-ctx.Done():
 						return
 					}
@@ -313,8 +342,8 @@ func (m *ConsumerManager) fetchLoop(
 				wg.Add(1)
 				go func() {
 					defer func() {
-						if m.sem != nil {
-							<-m.sem
+						if sem != nil {
+							<-sem
 						}
 						wg.Done()
 					}()

--- a/pkg/broker/filter/consumer_nats_test.go
+++ b/pkg/broker/filter/consumer_nats_test.go
@@ -841,6 +841,96 @@ func TestSubscribeTrigger_RestartTriggers(t *testing.T) {
 	}
 }
 
+// TestUnsubscribeTrigger_WaitsForInflightDispatches verifies that
+// UnsubscribeTrigger does not return until every dispatch goroutine spawned
+// by the fetch loop has exited. Without this guarantee, in-flight goroutines
+// could race with sub.Unsubscribe (msg.Ack on a closed subscription) and with
+// handler.Cleanup (concurrent h.filter.Filter vs h.filter.Cleanup).
+func TestUnsubscribeTrigger_WaitsForInflightDispatches(t *testing.T) {
+	s := natsTesting.RunBasicJetstreamServer()
+	defer natsTesting.ShutdownJSServerAndRemoveStorage(t, s)
+	conn, js := natsTesting.JsClient(t, s)
+	defer conn.Close()
+
+	ctx := logging.WithLogger(context.Background(), zap.NewNop().Sugar())
+
+	namespace := "default"
+	brokerName := "drain-broker"
+	triggerUID := "drain-trigger-uid-001"
+
+	setupStreamAndConsumer(t, js, namespace, brokerName, triggerUID)
+
+	// HTTP server that signals when a request arrives, then blocks until the
+	// client's request context is cancelled. dispatchCancel (fired from
+	// UnsubscribeTrigger) propagates through msgCtx, which cancels the
+	// dispatcher's HTTP client, which closes the connection — the server's
+	// r.Context() observes Done and the handler returns.
+	received := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case received <- struct{}{}:
+		default:
+		}
+		select {
+		case <-r.Context().Done():
+		case <-time.After(10 * time.Second):
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cm := newConsumerManagerForTest(t, ctx, conn, js, &ConsumerManagerConfig{
+		FetchBatchSize: 2,
+		FetchTimeout:   100 * time.Millisecond,
+		MaxConcurrency: 5,
+	})
+
+	broker := makeTestBrokerForNats(namespace, brokerName)
+	trigger := makeTriggerWithUID(namespace, "drain-trigger", brokerName, triggerUID)
+
+	subscriberURL, _ := apis.ParseURL(srv.URL)
+	subscriber := duckv1.Addressable{URL: subscriberURL}
+
+	if err := cm.SubscribeTrigger(trigger, broker, subscriber, nil, nil, nil, nil); err != nil {
+		t.Fatalf("SubscribeTrigger: %v", err)
+	}
+
+	// Capture sub before unsubscribe so we can inspect its inflight WG after.
+	cm.mu.RLock()
+	sub := cm.subscriptions[triggerUID]
+	cm.mu.RUnlock()
+
+	publishSubject := brokerutils.BrokerPublishSubjectName(namespace, brokerName)
+	publishStructuredCE(t, js, publishSubject, "drain-event-id")
+
+	// Wait for a dispatch goroutine to actually be in flight.
+	select {
+	case <-received:
+	case <-time.After(5 * time.Second):
+		t.Fatal("dispatch never reached the subscriber")
+	}
+
+	// Unsubscribe; this should block until every inflight dispatch goroutine
+	// has exited, then tear down the NATS subscription and handler.
+	if err := cm.UnsubscribeTrigger(triggerUID); err != nil {
+		t.Fatalf("UnsubscribeTrigger: %v", err)
+	}
+
+	// Post-condition: sub.inflight must be fully drained. A fresh Wait must
+	// return effectively immediately. If unsubscribe failed to wait, this Wait
+	// would still block until the dispatch goroutine finally finishes.
+	done := make(chan struct{})
+	go func() {
+		sub.inflight.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Error("sub.inflight was not drained when UnsubscribeTrigger returned")
+	}
+}
+
 // TestSubscribeTrigger_UpdateInPlace verifies that re-subscribing an existing trigger
 // updates the handler in place without creating a new subscription.
 func TestSubscribeTrigger_UpdateInPlace(t *testing.T) {

--- a/pkg/broker/filter/consumer_nats_test.go
+++ b/pkg/broker/filter/consumer_nats_test.go
@@ -517,6 +517,330 @@ func TestFetchLoop_DynamicBatchSize(t *testing.T) {
 	}
 }
 
+// TestSubscribeTrigger_RestartOnAnnotationChange verifies that changing any of
+// the three fetch-related annotations causes the fetch loop to restart with
+// the new parameters, while the dispatch context (and any in-flight HTTP calls
+// it parents) survives.
+func TestSubscribeTrigger_RestartOnAnnotationChange(t *testing.T) {
+	s := natsTesting.RunBasicJetstreamServer()
+	defer natsTesting.ShutdownJSServerAndRemoveStorage(t, s)
+	conn, js := natsTesting.JsClient(t, s)
+	defer conn.Close()
+
+	ctx := logging.WithLogger(context.Background(), zap.NewNop().Sugar())
+
+	namespace := "default"
+	brokerName := "restart-broker"
+	triggerUID := "restart-trigger-uid-001"
+
+	setupStreamAndConsumer(t, js, namespace, brokerName, triggerUID)
+
+	cm := newConsumerManagerForTest(t, ctx, conn, js, &ConsumerManagerConfig{
+		FetchBatchSize: 5,
+		FetchTimeout:   100 * time.Millisecond,
+		MaxConcurrency: 4,
+	})
+	defer cm.Close() //nolint:errcheck
+
+	broker := makeTestBrokerForNats(namespace, brokerName)
+	trigger := makeTriggerWithUID(namespace, "restart-trigger", brokerName, triggerUID)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	subscriberURL, _ := apis.ParseURL(srv.URL)
+	subscriber := duckv1.Addressable{URL: subscriberURL}
+
+	if err := cm.SubscribeTrigger(trigger, broker, subscriber, nil, nil, nil, nil); err != nil {
+		t.Fatalf("SubscribeTrigger (first): %v", err)
+	}
+
+	cm.mu.RLock()
+	first := cm.subscriptions[triggerUID]
+	firstSem := first.sem
+	firstDone := first.done
+	firstDispatchCtx := first.dispatchCtx
+	cm.mu.RUnlock()
+
+	if got, want := cap(firstSem), 4; got != want {
+		t.Fatalf("initial sem cap = %d, want %d", got, want)
+	}
+
+	// Update annotations on the same trigger UID.
+	trigger.Annotations = map[string]string{
+		TriggerFetchBatchSizeAnnotation: "8",
+		TriggerFetchTimeoutAnnotation:   "250ms",
+		TriggerMaxConcurrencyAnnotation: "12",
+	}
+
+	if err := cm.SubscribeTrigger(trigger, broker, subscriber, nil, nil, nil, nil); err != nil {
+		t.Fatalf("SubscribeTrigger (restart): %v", err)
+	}
+
+	cm.mu.RLock()
+	second := cm.subscriptions[triggerUID]
+	cm.mu.RUnlock()
+
+	if second != first {
+		t.Errorf("subscription pointer changed on restart; in-place update expected")
+	}
+	if got, want := second.fetchBatchSize, 8; got != want {
+		t.Errorf("fetchBatchSize = %d, want %d", got, want)
+	}
+	if got, want := second.fetchTimeout, 250*time.Millisecond; got != want {
+		t.Errorf("fetchTimeout = %v, want %v", got, want)
+	}
+	if got, want := second.maxConcurrency, 12; got != want {
+		t.Errorf("maxConcurrency = %d, want %d", got, want)
+	}
+	if got, want := cap(second.sem), 12; got != want {
+		t.Errorf("sem cap = %d, want %d (new semaphore should be sized to new max-concurrency)", got, want)
+	}
+	if second.sem == firstSem {
+		t.Errorf("sem channel was reused; expected a fresh channel on restart")
+	}
+	if second.done == firstDone {
+		t.Errorf("done channel was reused; expected a fresh channel on restart")
+	}
+	if second.dispatchCtx != firstDispatchCtx {
+		t.Errorf("dispatchCtx changed across restart; expected it to survive")
+	}
+	if second.dispatchCtx.Err() != nil {
+		t.Errorf("dispatchCtx was cancelled across restart: %v", second.dispatchCtx.Err())
+	}
+
+	// Old fetch loop should have observed cancel and closed firstDone.
+	select {
+	case <-firstDone:
+	case <-time.After(2 * time.Second):
+		t.Errorf("old fetch loop's done channel was not closed within 2s")
+	}
+}
+
+// TestSubscribeTrigger_NoRestartWhenAnnotationsUnchanged verifies that re-
+// subscribing without changing any fetch-related annotation does not restart
+// the fetch loop.
+func TestSubscribeTrigger_NoRestartWhenAnnotationsUnchanged(t *testing.T) {
+	s := natsTesting.RunBasicJetstreamServer()
+	defer natsTesting.ShutdownJSServerAndRemoveStorage(t, s)
+	conn, js := natsTesting.JsClient(t, s)
+	defer conn.Close()
+
+	ctx := logging.WithLogger(context.Background(), zap.NewNop().Sugar())
+
+	namespace := "default"
+	brokerName := "no-restart-broker"
+	triggerUID := "no-restart-trigger-uid-001"
+
+	setupStreamAndConsumer(t, js, namespace, brokerName, triggerUID)
+
+	cm := newConsumerManagerForTest(t, ctx, conn, js, &ConsumerManagerConfig{
+		FetchBatchSize: 3,
+		FetchTimeout:   100 * time.Millisecond,
+		MaxConcurrency: 6,
+	})
+	defer cm.Close() //nolint:errcheck
+
+	broker := makeTestBrokerForNats(namespace, brokerName)
+	trigger := makeTriggerWithUID(namespace, "no-restart-trigger", brokerName, triggerUID)
+
+	url1, _ := apis.ParseURL("http://localhost:9996")
+	url2, _ := apis.ParseURL("http://localhost:9995")
+
+	if err := cm.SubscribeTrigger(trigger, broker, duckv1.Addressable{URL: url1}, nil, nil, nil, nil); err != nil {
+		t.Fatalf("SubscribeTrigger (first): %v", err)
+	}
+
+	cm.mu.RLock()
+	first := cm.subscriptions[triggerUID]
+	firstSem := first.sem
+	firstDone := first.done
+	cm.mu.RUnlock()
+
+	// Same trigger, no annotations — should be a pure in-place handler update.
+	if err := cm.SubscribeTrigger(trigger, broker, duckv1.Addressable{URL: url2}, nil, nil, nil, nil); err != nil {
+		t.Fatalf("SubscribeTrigger (second): %v", err)
+	}
+
+	cm.mu.RLock()
+	second := cm.subscriptions[triggerUID]
+	cm.mu.RUnlock()
+
+	if second.sem != firstSem {
+		t.Errorf("sem was replaced when annotations did not change")
+	}
+	if second.done != firstDone {
+		t.Errorf("done channel was replaced when annotations did not change")
+	}
+
+	// firstDone should NOT have been closed.
+	select {
+	case <-firstDone:
+		t.Errorf("fetch loop's done channel was closed despite no annotation change")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// TestSubscribeTrigger_RestartTriggers verifies that the fetch loop restarts
+// iff the *effective* fetch parameters would differ — not whenever the raw
+// annotation map changes. Both sides of the comparison run through the same
+// parser, so e.g. an annotation whose value equals the manager default is a
+// no-op, an unparseable annotation is a no-op (both resolve to default), and
+// removing an annotation only restarts if the default differs from the value
+// previously in effect.
+func TestSubscribeTrigger_RestartTriggers(t *testing.T) {
+	s := natsTesting.RunBasicJetstreamServer()
+	defer natsTesting.ShutdownJSServerAndRemoveStorage(t, s)
+	conn, js := natsTesting.JsClient(t, s)
+	defer conn.Close()
+
+	ctx := logging.WithLogger(context.Background(), zap.NewNop().Sugar())
+
+	// Manager defaults: batch=5, timeout=100ms, maxConc=6.
+	cfg := &ConsumerManagerConfig{
+		FetchBatchSize: 5,
+		FetchTimeout:   100 * time.Millisecond,
+		MaxConcurrency: 6,
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	subscriberURL, _ := apis.ParseURL(srv.URL)
+	subscriber := duckv1.Addressable{URL: subscriberURL}
+
+	cases := []struct {
+		name        string
+		firstAnn    map[string]string
+		secondAnn   map[string]string
+		wantRestart bool
+	}{
+		{
+			name:        "no annotations on either side",
+			firstAnn:    nil,
+			secondAnn:   nil,
+			wantRestart: false,
+		},
+		{
+			name:        "same explicit values on both sides",
+			firstAnn:    map[string]string{TriggerFetchBatchSizeAnnotation: "8"},
+			secondAnn:   map[string]string{TriggerFetchBatchSizeAnnotation: "8"},
+			wantRestart: false,
+		},
+		{
+			name:        "annotation value equals manager default",
+			firstAnn:    nil,
+			secondAnn:   map[string]string{TriggerFetchBatchSizeAnnotation: "5"},
+			wantRestart: false,
+		},
+		{
+			name:        "remove annotation whose value equalled default",
+			firstAnn:    map[string]string{TriggerFetchBatchSizeAnnotation: "5"},
+			secondAnn:   nil,
+			wantRestart: false,
+		},
+		{
+			name:        "invalid annotation on both sides resolves to default",
+			firstAnn:    map[string]string{TriggerFetchBatchSizeAnnotation: "garbage"},
+			secondAnn:   map[string]string{TriggerFetchBatchSizeAnnotation: "also-garbage"},
+			wantRestart: false,
+		},
+		{
+			name:        "unrelated annotation added — no fetch params touched",
+			firstAnn:    nil,
+			secondAnn:   map[string]string{"unrelated/key": "anything"},
+			wantRestart: false,
+		},
+		{
+			name:        "batch size changed",
+			firstAnn:    map[string]string{TriggerFetchBatchSizeAnnotation: "8"},
+			secondAnn:   map[string]string{TriggerFetchBatchSizeAnnotation: "16"},
+			wantRestart: true,
+		},
+		{
+			name:        "only fetch-timeout changed",
+			firstAnn:    nil,
+			secondAnn:   map[string]string{TriggerFetchTimeoutAnnotation: "500ms"},
+			wantRestart: true,
+		},
+		{
+			name:        "only max-concurrency changed",
+			firstAnn:    nil,
+			secondAnn:   map[string]string{TriggerMaxConcurrencyAnnotation: "20"},
+			wantRestart: true,
+		},
+		{
+			name:        "removing annotation now diverges from default",
+			firstAnn:    map[string]string{TriggerFetchBatchSizeAnnotation: "9"},
+			secondAnn:   nil,
+			wantRestart: true,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			brokerName := fmt.Sprintf("restart-cases-broker-%d", i)
+			triggerUID := fmt.Sprintf("restart-cases-uid-%d", i)
+			namespace := "default"
+
+			setupStreamAndConsumer(t, js, namespace, brokerName, triggerUID)
+
+			cm := newConsumerManagerForTest(t, ctx, conn, js, cfg)
+			defer cm.Close() //nolint:errcheck
+
+			broker := makeTestBrokerForNats(namespace, brokerName)
+			trigger := makeTriggerWithUID(namespace, "trig", brokerName, triggerUID)
+
+			trigger.Annotations = tc.firstAnn
+			if err := cm.SubscribeTrigger(trigger, broker, subscriber, nil, nil, nil, nil); err != nil {
+				t.Fatalf("first SubscribeTrigger: %v", err)
+			}
+
+			cm.mu.RLock()
+			before := cm.subscriptions[triggerUID]
+			beforeDone := before.done
+			beforeSem := before.sem
+			cm.mu.RUnlock()
+
+			trigger.Annotations = tc.secondAnn
+			if err := cm.SubscribeTrigger(trigger, broker, subscriber, nil, nil, nil, nil); err != nil {
+				t.Fatalf("second SubscribeTrigger: %v", err)
+			}
+
+			cm.mu.RLock()
+			after := cm.subscriptions[triggerUID]
+			afterDone := after.done
+			afterSem := after.sem
+			cm.mu.RUnlock()
+
+			restarted := beforeDone != afterDone || beforeSem != afterSem
+
+			if restarted != tc.wantRestart {
+				t.Errorf("restart = %v, want %v", restarted, tc.wantRestart)
+			}
+
+			if tc.wantRestart {
+				// The old done channel must have been closed.
+				select {
+				case <-beforeDone:
+				case <-time.After(2 * time.Second):
+					t.Errorf("restart claimed but old done channel never closed")
+				}
+			} else {
+				// The old done channel must NOT have been closed.
+				select {
+				case <-beforeDone:
+					t.Errorf("no-restart claimed but old done channel was closed")
+				case <-time.After(100 * time.Millisecond):
+				}
+			}
+		})
+	}
+}
+
 // TestSubscribeTrigger_UpdateInPlace verifies that re-subscribing an existing trigger
 // updates the handler in place without creating a new subscription.
 func TestSubscribeTrigger_UpdateInPlace(t *testing.T) {

--- a/pkg/broker/filter/consumer_nats_test.go
+++ b/pkg/broker/filter/consumer_nats_test.go
@@ -1,0 +1,565 @@
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filter
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
+	"knative.dev/pkg/logging"
+
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+	"knative.dev/eventing/pkg/eventingtls"
+	"knative.dev/eventing/pkg/kncloudevents"
+
+	brokerutils "knative.dev/eventing-natss/pkg/broker/utils"
+	natsTesting "knative.dev/eventing-natss/pkg/channel/jetstream/dispatcher/testing"
+)
+
+// setupStreamAndConsumer creates a JetStream stream and durable pull consumer for testing.
+// Returns (streamName, consumerName).
+func setupStreamAndConsumer(t *testing.T, js nats.JetStreamContext, namespace, brokerName, triggerUID string) (string, string) {
+	t.Helper()
+
+	broker := &eventingv1.Broker{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      brokerName,
+		},
+	}
+
+	streamName := brokerutils.BrokerStreamName(broker)
+	consumerName := brokerutils.TriggerConsumerName(triggerUID)
+	publishSubject := brokerutils.BrokerPublishSubjectName(namespace, brokerName)
+	filterSubject := publishSubject + ".>"
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     streamName,
+		Subjects: []string{filterSubject},
+		Storage:  nats.MemoryStorage,
+	})
+	if err != nil {
+		t.Fatalf("AddStream(%q): %v", streamName, err)
+	}
+
+	_, err = js.AddConsumer(streamName, &nats.ConsumerConfig{
+		Durable:       consumerName,
+		AckPolicy:     nats.AckExplicitPolicy,
+		FilterSubject: filterSubject,
+		AckWait:       30 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("AddConsumer(%q, %q): %v", streamName, consumerName, err)
+	}
+
+	return streamName, consumerName
+}
+
+// makeTestBrokerForNats creates a minimal Broker with the given namespace and name.
+func makeTestBrokerForNats(namespace, name string) *eventingv1.Broker {
+	return &eventingv1.Broker{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+}
+
+// makeTriggerWithUID creates a Trigger with a specific UID.
+func makeTriggerWithUID(namespace, name, brokerName, uid string) *eventingv1.Trigger {
+	return &eventingv1.Trigger{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			UID:       types.UID(uid),
+		},
+		Spec: eventingv1.TriggerSpec{
+			Broker: brokerName,
+		},
+	}
+}
+
+// newConsumerManagerForTest creates a ConsumerManager with a real NATS connection.
+func newConsumerManagerForTest(t *testing.T, ctx context.Context, conn *nats.Conn, js nats.JetStreamContext, cfg *ConsumerManagerConfig) *ConsumerManager {
+	t.Helper()
+	dispatcher := kncloudevents.NewDispatcher(eventingtls.ClientConfig{}, nil)
+
+	fetchBatchSize := DefaultFetchBatchSize
+	fetchTimeout := DefaultFetchTimeout
+	maxConcurrency := DefaultMaxConcurrency
+
+	if cfg != nil {
+		if cfg.FetchBatchSize > 0 {
+			fetchBatchSize = cfg.FetchBatchSize
+		}
+		if cfg.FetchTimeout > 0 {
+			fetchTimeout = cfg.FetchTimeout
+		}
+		if cfg.MaxConcurrency > 0 {
+			maxConcurrency = cfg.MaxConcurrency
+		}
+	}
+
+	return &ConsumerManager{
+		logger:                logging.FromContext(ctx),
+		ctx:                   ctx,
+		js:                    js,
+		conn:                  conn,
+		fetchBatchSize:        fetchBatchSize,
+		fetchTimeout:          fetchTimeout,
+		defaultMaxConcurrency: maxConcurrency,
+		dispatcher:            dispatcher,
+		subscriptions:         make(map[string]*TriggerSubscription),
+	}
+}
+
+// publishStructuredCE publishes a structured CloudEvent to the given subject.
+// The subject must match the stream's filter subject. Since the stream uses
+// the pattern "namespace.broker._knative_broker.>", we append ".event" to
+// the base publish subject so it matches the wildcard.
+func publishStructuredCE(t *testing.T, js nats.JetStreamContext, baseSubject, eventID string) {
+	t.Helper()
+	subject := baseSubject + ".event"
+	body := fmt.Sprintf(
+		`{"specversion":"1.0","type":"test.type","source":"test/source","id":"%s"}`,
+		eventID,
+	)
+	msg := &nats.Msg{
+		Subject: subject,
+		Header:  nats.Header{"Content-Type": []string{"application/cloudevents+json"}},
+		Data:    []byte(body),
+	}
+	if _, err := js.PublishMsg(msg); err != nil {
+		t.Fatalf("PublishMsg(%q): %v", subject, err)
+	}
+}
+
+// contextWithFakeKube returns a context with a fake Kubernetes client injected.
+// This satisfies auth.NewOIDCTokenProvider which calls kubeclient.Get(ctx).
+func contextWithFakeKube(t *testing.T) context.Context {
+	t.Helper()
+	ctx := logging.WithLogger(context.Background(), zap.NewNop().Sugar())
+	ctx, _ = fakekubeclient.With(ctx)
+	return ctx
+}
+
+// TestNewConsumerManager_Fields verifies that NewConsumerManager applies config values correctly.
+func TestNewConsumerManager_Fields(t *testing.T) {
+	s := natsTesting.RunBasicJetstreamServer()
+	defer natsTesting.ShutdownJSServerAndRemoveStorage(t, s)
+	conn, js := natsTesting.JsClient(t, s)
+	defer conn.Close()
+
+	ctx := contextWithFakeKube(t)
+
+	cfg := &ConsumerManagerConfig{
+		FetchBatchSize: 7,
+		FetchTimeout:   350 * time.Millisecond,
+		MaxConcurrency: 15,
+	}
+	cm := NewConsumerManager(ctx, conn, js, cfg)
+
+	if cm.fetchBatchSize != 7 {
+		t.Errorf("fetchBatchSize = %d, want 7", cm.fetchBatchSize)
+	}
+	if cm.fetchTimeout != 350*time.Millisecond {
+		t.Errorf("fetchTimeout = %v, want 350ms", cm.fetchTimeout)
+	}
+	if cm.defaultMaxConcurrency != 15 {
+		t.Errorf("defaultMaxConcurrency = %d, want 15", cm.defaultMaxConcurrency)
+	}
+}
+
+// TestNewConsumerManager_DefaultFields verifies that nil config falls back to defaults.
+func TestNewConsumerManager_DefaultFields(t *testing.T) {
+	s := natsTesting.RunBasicJetstreamServer()
+	defer natsTesting.ShutdownJSServerAndRemoveStorage(t, s)
+	conn, js := natsTesting.JsClient(t, s)
+	defer conn.Close()
+
+	ctx := contextWithFakeKube(t)
+
+	cm := NewConsumerManager(ctx, conn, js, nil)
+
+	if cm.fetchBatchSize != DefaultFetchBatchSize {
+		t.Errorf("fetchBatchSize = %d, want %d", cm.fetchBatchSize, DefaultFetchBatchSize)
+	}
+	if cm.fetchTimeout != DefaultFetchTimeout {
+		t.Errorf("fetchTimeout = %v, want %v", cm.fetchTimeout, DefaultFetchTimeout)
+	}
+	if cm.defaultMaxConcurrency != DefaultMaxConcurrency {
+		t.Errorf("defaultMaxConcurrency = %d, want %d", cm.defaultMaxConcurrency, DefaultMaxConcurrency)
+	}
+}
+
+// TestSubscribeTrigger_And_Unsubscribe verifies subscribe/unsubscribe lifecycle.
+func TestSubscribeTrigger_And_Unsubscribe(t *testing.T) {
+	s := natsTesting.RunBasicJetstreamServer()
+	defer natsTesting.ShutdownJSServerAndRemoveStorage(t, s)
+	conn, js := natsTesting.JsClient(t, s)
+	defer conn.Close()
+
+	ctx := logging.WithLogger(context.Background(), zap.NewNop().Sugar())
+
+	namespace := "default"
+	brokerName := "test-broker"
+	triggerUID := "subscribe-trigger-uid-001"
+
+	setupStreamAndConsumer(t, js, namespace, brokerName, triggerUID)
+
+	cm := newConsumerManagerForTest(t, ctx, conn, js, &ConsumerManagerConfig{
+		FetchBatchSize: 2,
+		FetchTimeout:   100 * time.Millisecond,
+		MaxConcurrency: 5,
+	})
+
+	broker := makeTestBrokerForNats(namespace, brokerName)
+	trigger := makeTriggerWithUID(namespace, "test-trigger", brokerName, triggerUID)
+
+	subscriberURL, _ := apis.ParseURL("http://localhost:9999")
+	subscriber := duckv1.Addressable{URL: subscriberURL}
+
+	err := cm.SubscribeTrigger(trigger, broker, subscriber, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("SubscribeTrigger: %v", err)
+	}
+
+	if !cm.HasSubscription(triggerUID) {
+		t.Error("HasSubscription() = false after subscribe, want true")
+	}
+
+	err = cm.UnsubscribeTrigger(triggerUID)
+	if err != nil {
+		t.Fatalf("UnsubscribeTrigger: %v", err)
+	}
+
+	if cm.HasSubscription(triggerUID) {
+		t.Error("HasSubscription() = true after unsubscribe, want false")
+	}
+	if cm.GetSubscriptionCount() != 0 {
+		t.Errorf("GetSubscriptionCount() = %d, want 0", cm.GetSubscriptionCount())
+	}
+}
+
+// TestFetchLoop_DispatchesMessages verifies that messages published to the stream
+// are fetched and dispatched to the subscriber httptest server.
+func TestFetchLoop_DispatchesMessages(t *testing.T) {
+	s := natsTesting.RunBasicJetstreamServer()
+	defer natsTesting.ShutdownJSServerAndRemoveStorage(t, s)
+	conn, js := natsTesting.JsClient(t, s)
+	defer conn.Close()
+
+	ctx := logging.WithLogger(context.Background(), zap.NewNop().Sugar())
+
+	namespace := "default"
+	brokerName := "dispatch-broker"
+	triggerUID := "dispatch-trigger-uid-001"
+
+	setupStreamAndConsumer(t, js, namespace, brokerName, triggerUID)
+
+	var receivedCount int64
+	received := make(chan struct{}, 10)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&receivedCount, 1)
+		received <- struct{}{}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cm := newConsumerManagerForTest(t, ctx, conn, js, &ConsumerManagerConfig{
+		FetchBatchSize: 5,
+		FetchTimeout:   200 * time.Millisecond,
+		MaxConcurrency: 10,
+	})
+
+	broker := makeTestBrokerForNats(namespace, brokerName)
+	trigger := makeTriggerWithUID(namespace, "dispatch-trigger", brokerName, triggerUID)
+
+	subscriberURL, _ := apis.ParseURL(srv.URL)
+	subscriber := duckv1.Addressable{URL: subscriberURL}
+
+	err := cm.SubscribeTrigger(trigger, broker, subscriber, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("SubscribeTrigger: %v", err)
+	}
+	defer cm.UnsubscribeTrigger(triggerUID) //nolint:errcheck
+
+	publishSubject := brokerutils.BrokerPublishSubjectName(namespace, brokerName)
+	for i := 0; i < 3; i++ {
+		publishStructuredCE(t, js, publishSubject, fmt.Sprintf("event-id-%d", i))
+	}
+
+	deadline := time.After(10 * time.Second)
+	for got := 0; got < 3; {
+		select {
+		case <-received:
+			got++
+		case <-deadline:
+			t.Fatalf("timed out waiting for messages: got %d, want 3", got)
+		}
+	}
+
+	if n := atomic.LoadInt64(&receivedCount); n != 3 {
+		t.Errorf("subscriber received %d requests, want 3", n)
+	}
+}
+
+// TestFetchLoop_ContextCancellation verifies that UnsubscribeTrigger stops the fetch loop.
+func TestFetchLoop_ContextCancellation(t *testing.T) {
+	s := natsTesting.RunBasicJetstreamServer()
+	defer natsTesting.ShutdownJSServerAndRemoveStorage(t, s)
+	conn, js := natsTesting.JsClient(t, s)
+	defer conn.Close()
+
+	ctx := logging.WithLogger(context.Background(), zap.NewNop().Sugar())
+
+	namespace := "default"
+	brokerName := "cancel-broker"
+	triggerUID := "cancel-trigger-uid-001"
+
+	setupStreamAndConsumer(t, js, namespace, brokerName, triggerUID)
+
+	cm := newConsumerManagerForTest(t, ctx, conn, js, &ConsumerManagerConfig{
+		FetchBatchSize: 2,
+		FetchTimeout:   100 * time.Millisecond,
+		MaxConcurrency: 5,
+	})
+
+	broker := makeTestBrokerForNats(namespace, brokerName)
+	trigger := makeTriggerWithUID(namespace, "cancel-trigger", brokerName, triggerUID)
+
+	// Subscriber that just returns OK.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	subscriberURL, _ := apis.ParseURL(srv.URL)
+	subscriber := duckv1.Addressable{URL: subscriberURL}
+
+	err := cm.SubscribeTrigger(trigger, broker, subscriber, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("SubscribeTrigger: %v", err)
+	}
+
+	if !cm.HasSubscription(triggerUID) {
+		t.Fatal("HasSubscription should be true after subscribe")
+	}
+
+	// Unsubscribe should stop the fetch loop quickly.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := cm.UnsubscribeTrigger(triggerUID); err != nil {
+			t.Errorf("UnsubscribeTrigger: %v", err)
+		}
+	}()
+
+	select {
+	case <-done:
+		// Good.
+	case <-time.After(5 * time.Second):
+		t.Fatal("UnsubscribeTrigger did not return within 5 seconds")
+	}
+
+	if cm.HasSubscription(triggerUID) {
+		t.Error("HasSubscription() = true after unsubscribe, want false")
+	}
+}
+
+// TestClose_WithActiveSubscriptions verifies that Close() stops all subscriptions.
+func TestClose_WithActiveSubscriptions(t *testing.T) {
+	s := natsTesting.RunBasicJetstreamServer()
+	defer natsTesting.ShutdownJSServerAndRemoveStorage(t, s)
+	conn, js := natsTesting.JsClient(t, s)
+	defer conn.Close()
+
+	ctx := logging.WithLogger(context.Background(), zap.NewNop().Sugar())
+
+	namespace := "default"
+	brokerName := "close-broker"
+
+	triggerUID1 := "close-trigger-uid-001"
+	triggerUID2 := "close-trigger-uid-002"
+
+	setupStreamAndConsumer(t, js, namespace, brokerName, triggerUID1)
+	setupStreamAndConsumer(t, js, namespace, brokerName, triggerUID2)
+
+	cm := newConsumerManagerForTest(t, ctx, conn, js, &ConsumerManagerConfig{
+		FetchBatchSize: 2,
+		FetchTimeout:   100 * time.Millisecond,
+		MaxConcurrency: 5,
+	})
+
+	broker := makeTestBrokerForNats(namespace, brokerName)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	subscriberURL, _ := apis.ParseURL(srv.URL)
+	subscriber := duckv1.Addressable{URL: subscriberURL}
+
+	trigger1 := makeTriggerWithUID(namespace, "close-trigger-1", brokerName, triggerUID1)
+	trigger2 := makeTriggerWithUID(namespace, "close-trigger-2", brokerName, triggerUID2)
+
+	if err := cm.SubscribeTrigger(trigger1, broker, subscriber, nil, nil, nil, nil); err != nil {
+		t.Fatalf("SubscribeTrigger(trigger1): %v", err)
+	}
+	if err := cm.SubscribeTrigger(trigger2, broker, subscriber, nil, nil, nil, nil); err != nil {
+		t.Fatalf("SubscribeTrigger(trigger2): %v", err)
+	}
+
+	if cm.GetSubscriptionCount() != 2 {
+		t.Fatalf("GetSubscriptionCount() = %d, want 2", cm.GetSubscriptionCount())
+	}
+
+	if err := cm.Close(); err != nil {
+		t.Errorf("Close() error: %v", err)
+	}
+
+	if cm.GetSubscriptionCount() != 0 {
+		t.Errorf("GetSubscriptionCount() = %d, want 0 after Close()", cm.GetSubscriptionCount())
+	}
+}
+
+// TestFetchLoop_DynamicBatchSize verifies that the fetch loop respects semaphore capacity.
+func TestFetchLoop_DynamicBatchSize(t *testing.T) {
+	s := natsTesting.RunBasicJetstreamServer()
+	defer natsTesting.ShutdownJSServerAndRemoveStorage(t, s)
+	conn, js := natsTesting.JsClient(t, s)
+	defer conn.Close()
+
+	ctx := logging.WithLogger(context.Background(), zap.NewNop().Sugar())
+
+	namespace := "default"
+	brokerName := "dynamic-broker"
+	triggerUID := "dynamic-trigger-uid-001"
+
+	setupStreamAndConsumer(t, js, namespace, brokerName, triggerUID)
+
+	var receivedCount int64
+	received := make(chan struct{}, 20)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&receivedCount, 1)
+		received <- struct{}{}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// maxConcurrency=2 forces fetch loop to cap batch to 2 at a time.
+	cm := newConsumerManagerForTest(t, ctx, conn, js, &ConsumerManagerConfig{
+		FetchBatchSize: 5,
+		FetchTimeout:   200 * time.Millisecond,
+		MaxConcurrency: 2,
+	})
+
+	broker := makeTestBrokerForNats(namespace, brokerName)
+	trigger := makeTriggerWithUID(namespace, "dynamic-trigger", brokerName, triggerUID)
+
+	subscriberURL, _ := apis.ParseURL(srv.URL)
+	subscriber := duckv1.Addressable{URL: subscriberURL}
+
+	err := cm.SubscribeTrigger(trigger, broker, subscriber, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("SubscribeTrigger: %v", err)
+	}
+	defer cm.UnsubscribeTrigger(triggerUID) //nolint:errcheck
+
+	publishSubject := brokerutils.BrokerPublishSubjectName(namespace, brokerName)
+	const totalMessages = 5
+	for i := 0; i < totalMessages; i++ {
+		publishStructuredCE(t, js, publishSubject, fmt.Sprintf("dyn-event-id-%d", i))
+	}
+
+	deadline := time.After(15 * time.Second)
+	for got := 0; got < totalMessages; {
+		select {
+		case <-received:
+			got++
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d messages: got %d", totalMessages, got)
+		}
+	}
+
+	if n := atomic.LoadInt64(&receivedCount); n != totalMessages {
+		t.Errorf("received %d messages, want %d", n, totalMessages)
+	}
+}
+
+// TestSubscribeTrigger_UpdateInPlace verifies that re-subscribing an existing trigger
+// updates the handler in place without creating a new subscription.
+func TestSubscribeTrigger_UpdateInPlace(t *testing.T) {
+	s := natsTesting.RunBasicJetstreamServer()
+	defer natsTesting.ShutdownJSServerAndRemoveStorage(t, s)
+	conn, js := natsTesting.JsClient(t, s)
+	defer conn.Close()
+
+	ctx := logging.WithLogger(context.Background(), zap.NewNop().Sugar())
+
+	namespace := "default"
+	brokerName := "update-broker"
+	triggerUID := "update-trigger-uid-001"
+
+	setupStreamAndConsumer(t, js, namespace, brokerName, triggerUID)
+
+	cm := newConsumerManagerForTest(t, ctx, conn, js, &ConsumerManagerConfig{
+		FetchBatchSize: 2,
+		FetchTimeout:   100 * time.Millisecond,
+		MaxConcurrency: 5,
+	})
+
+	broker := makeTestBrokerForNats(namespace, brokerName)
+	trigger := makeTriggerWithUID(namespace, "update-trigger", brokerName, triggerUID)
+
+	url1, _ := apis.ParseURL("http://localhost:9998")
+	url2, _ := apis.ParseURL("http://localhost:9997")
+
+	err := cm.SubscribeTrigger(trigger, broker, duckv1.Addressable{URL: url1}, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("SubscribeTrigger (first): %v", err)
+	}
+
+	// Second call with same triggerUID — should update in place.
+	err = cm.SubscribeTrigger(trigger, broker, duckv1.Addressable{URL: url2}, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("SubscribeTrigger (second): %v", err)
+	}
+
+	// Still only one subscription.
+	if cm.GetSubscriptionCount() != 1 {
+		t.Errorf("GetSubscriptionCount() = %d, want 1 after update", cm.GetSubscriptionCount())
+	}
+
+	cm.Close() //nolint:errcheck
+}

--- a/pkg/broker/filter/consumer_test.go
+++ b/pkg/broker/filter/consumer_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap"
 	"knative.dev/pkg/logging"
 )
 
@@ -191,5 +192,291 @@ func TestUnsubscribeTrigger_NotFound(t *testing.T) {
 	err := cm.UnsubscribeTrigger("non-existent-uid")
 	if err != nil {
 		t.Errorf("UnsubscribeTrigger() unexpected error for non-existent UID: %v", err)
+	}
+}
+
+func TestDefaultMaxConcurrency(t *testing.T) {
+	if DefaultMaxConcurrency != 20 {
+		t.Errorf("DefaultMaxConcurrency = %v, want 20", DefaultMaxConcurrency)
+	}
+}
+
+func TestAnnotationConstants(t *testing.T) {
+	tests := []struct {
+		name  string
+		got   string
+		want  string
+	}{
+		{
+			name: "TriggerMaxConcurrencyAnnotation",
+			got:  TriggerMaxConcurrencyAnnotation,
+			want: "natsjetstream.eventing.knative.dev/max-concurrency",
+		},
+		{
+			name: "TriggerFetchBatchSizeAnnotation",
+			got:  TriggerFetchBatchSizeAnnotation,
+			want: "natsjetstream.eventing.knative.dev/fetch-batch-size",
+		},
+		{
+			name: "TriggerFetchTimeoutAnnotation",
+			got:  TriggerFetchTimeoutAnnotation,
+			want: "natsjetstream.eventing.knative.dev/fetch-timeout",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("%s = %q, want %q", tt.name, tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConsumerManagerConfig_MaxConcurrency(t *testing.T) {
+	tests := []struct {
+		name               string
+		config             *ConsumerManagerConfig
+		wantMaxConcurrency int
+	}{
+		{
+			name:               "nil config uses default",
+			config:             nil,
+			wantMaxConcurrency: DefaultMaxConcurrency,
+		},
+		{
+			name:               "zero MaxConcurrency uses default",
+			config:             &ConsumerManagerConfig{MaxConcurrency: 0},
+			wantMaxConcurrency: DefaultMaxConcurrency,
+		},
+		{
+			name:               "positive MaxConcurrency is used",
+			config:             &ConsumerManagerConfig{MaxConcurrency: 50},
+			wantMaxConcurrency: 50,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			maxConcurrency := DefaultMaxConcurrency
+
+			if tt.config != nil {
+				if tt.config.MaxConcurrency > 0 {
+					maxConcurrency = tt.config.MaxConcurrency
+				}
+			}
+
+			if maxConcurrency != tt.wantMaxConcurrency {
+				t.Errorf("maxConcurrency = %v, want %v", maxConcurrency, tt.wantMaxConcurrency)
+			}
+		})
+	}
+}
+
+func TestParseTriggerAnnotationInt(t *testing.T) {
+	logger := zap.NewNop().Sugar()
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		key         string
+		defaultVal  int
+		want        int
+	}{
+		{
+			name:        "absent key returns default",
+			annotations: map[string]string{},
+			key:         "some-key",
+			defaultVal:  10,
+			want:        10,
+		},
+		{
+			name:        "empty string returns default",
+			annotations: map[string]string{"some-key": ""},
+			key:         "some-key",
+			defaultVal:  10,
+			want:        10,
+		},
+		{
+			name:        "valid positive int is parsed",
+			annotations: map[string]string{"some-key": "42"},
+			key:         "some-key",
+			defaultVal:  10,
+			want:        42,
+		},
+		{
+			name:        "zero returns default",
+			annotations: map[string]string{"some-key": "0"},
+			key:         "some-key",
+			defaultVal:  10,
+			want:        10,
+		},
+		{
+			name:        "negative returns default",
+			annotations: map[string]string{"some-key": "-5"},
+			key:         "some-key",
+			defaultVal:  10,
+			want:        10,
+		},
+		{
+			name:        "non-numeric returns default",
+			annotations: map[string]string{"some-key": "abc"},
+			key:         "some-key",
+			defaultVal:  10,
+			want:        10,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseTriggerAnnotationInt(tt.annotations, tt.key, tt.defaultVal, logger)
+			if got != tt.want {
+				t.Errorf("parseTriggerAnnotationInt() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseTriggerAnnotationDuration(t *testing.T) {
+	logger := zap.NewNop().Sugar()
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		key         string
+		defaultVal  time.Duration
+		want        time.Duration
+	}{
+		{
+			name:        "absent key returns default",
+			annotations: map[string]string{},
+			key:         "some-key",
+			defaultVal:  200 * time.Millisecond,
+			want:        200 * time.Millisecond,
+		},
+		{
+			name:        "empty string returns default",
+			annotations: map[string]string{"some-key": ""},
+			key:         "some-key",
+			defaultVal:  200 * time.Millisecond,
+			want:        200 * time.Millisecond,
+		},
+		{
+			name:        "valid duration is parsed",
+			annotations: map[string]string{"some-key": "500ms"},
+			key:         "some-key",
+			defaultVal:  200 * time.Millisecond,
+			want:        500 * time.Millisecond,
+		},
+		{
+			name:        "zero duration returns default",
+			annotations: map[string]string{"some-key": "0s"},
+			key:         "some-key",
+			defaultVal:  200 * time.Millisecond,
+			want:        200 * time.Millisecond,
+		},
+		{
+			name:        "negative duration returns default",
+			annotations: map[string]string{"some-key": "-1s"},
+			key:         "some-key",
+			defaultVal:  200 * time.Millisecond,
+			want:        200 * time.Millisecond,
+		},
+		{
+			name:        "non-duration string returns default",
+			annotations: map[string]string{"some-key": "abc"},
+			key:         "some-key",
+			defaultVal:  200 * time.Millisecond,
+			want:        200 * time.Millisecond,
+		},
+		{
+			name:        "nil annotations map returns default without panic",
+			annotations: nil,
+			key:         "some-key",
+			defaultVal:  200 * time.Millisecond,
+			want:        200 * time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseTriggerAnnotationDuration(tt.annotations, tt.key, tt.defaultVal, logger)
+			if got != tt.want {
+				t.Errorf("parseTriggerAnnotationDuration() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDynamicBatchSizeCapping(t *testing.T) {
+	tests := []struct {
+		name           string
+		capacity       int
+		occupied       int
+		fetchBatchSize int
+		wantBatchSize  int
+	}{
+		{
+			name:           "all free and batchSize fits within capacity",
+			capacity:       20,
+			occupied:       0,
+			fetchBatchSize: 10,
+			wantBatchSize:  10,
+		},
+		{
+			name:           "all free but batchSize exceeds capacity",
+			capacity:       5,
+			occupied:       0,
+			fetchBatchSize: 10,
+			wantBatchSize:  5,
+		},
+		{
+			name:           "partially occupied and batchSize fits within available",
+			capacity:       20,
+			occupied:       5,
+			fetchBatchSize: 10,
+			wantBatchSize:  10,
+		},
+		{
+			name:           "partially occupied and batchSize exceeds available",
+			capacity:       20,
+			occupied:       15,
+			fetchBatchSize: 10,
+			wantBatchSize:  5,
+		},
+		{
+			name:           "one slot free",
+			capacity:       20,
+			occupied:       19,
+			fetchBatchSize: 10,
+			wantBatchSize:  1,
+		},
+		{
+			name:           "all occupied returns zero",
+			capacity:       20,
+			occupied:       20,
+			fetchBatchSize: 10,
+			wantBatchSize:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sem := make(chan struct{}, tt.capacity)
+			for i := 0; i < tt.occupied; i++ {
+				sem <- struct{}{}
+			}
+
+			available := cap(sem) - len(sem)
+			batchSize := tt.fetchBatchSize
+			if available < batchSize {
+				batchSize = available
+			}
+
+			if batchSize != tt.wantBatchSize {
+				t.Errorf("batchSize = %v, want %v (available=%v, fetchBatchSize=%v)",
+					batchSize, tt.wantBatchSize, available, tt.fetchBatchSize)
+			}
+		})
 	}
 }

--- a/pkg/broker/filter/consumer_test.go
+++ b/pkg/broker/filter/consumer_test.go
@@ -203,9 +203,9 @@ func TestDefaultMaxConcurrency(t *testing.T) {
 
 func TestAnnotationConstants(t *testing.T) {
 	tests := []struct {
-		name  string
-		got   string
-		want  string
+		name string
+		got  string
+		want string
 	}{
 		{
 			name: "TriggerMaxConcurrencyAnnotation",

--- a/pkg/broker/filter/controller.go
+++ b/pkg/broker/filter/controller.go
@@ -43,6 +43,7 @@ type envConfig struct {
 	NatsURL        string        `envconfig:"NATS_URL" required:"true"`
 	FetchBatchSize int           `envconfig:"CONSUMER_FETCH_BATCH_SIZE" default:"0"`
 	FetchTimeout   time.Duration `envconfig:"CONSUMER_FETCH_TIMEOUT" default:"0"`
+	MaxConcurrency int           `envconfig:"CONSUMER_MAX_CONCURRENCY" default:"0"`
 }
 
 // NewController creates a new filter controller
@@ -74,6 +75,7 @@ func NewController(ctx context.Context, _ configmap.Watcher) *controller.Impl {
 	consumerConfig := &ConsumerManagerConfig{
 		FetchBatchSize: env.FetchBatchSize,
 		FetchTimeout:   env.FetchTimeout,
+		MaxConcurrency: env.MaxConcurrency,
 	}
 	consumerManager := NewConsumerManager(ctx, natsConn, js, consumerConfig)
 

--- a/pkg/broker/filter/controller_test.go
+++ b/pkg/broker/filter/controller_test.go
@@ -86,3 +86,41 @@ func TestFilterTriggersByBrokerClass(t *testing.T) {
 		})
 	}
 }
+
+func TestEnvConfig_MaxConcurrency(t *testing.T) {
+	tests := []struct {
+		name               string
+		configMaxConcur    int
+		wantMaxConcurrency int
+	}{
+		{
+			name:               "zero uses default",
+			configMaxConcur:    0,
+			wantMaxConcurrency: DefaultMaxConcurrency,
+		},
+		{
+			name:               "positive value is used",
+			configMaxConcur:    40,
+			wantMaxConcurrency: 40,
+		},
+		{
+			name:               "negative uses default",
+			configMaxConcur:    -1,
+			wantMaxConcurrency: DefaultMaxConcurrency,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			maxConcurrency := DefaultMaxConcurrency
+
+			if tt.configMaxConcur > 0 {
+				maxConcurrency = tt.configMaxConcur
+			}
+
+			if maxConcurrency != tt.wantMaxConcurrency {
+				t.Errorf("maxConcurrency = %v, want %v", maxConcurrency, tt.wantMaxConcurrency)
+			}
+		})
+	}
+}

--- a/pkg/broker/filter/handler.go
+++ b/pkg/broker/filter/handler.go
@@ -19,6 +19,7 @@ package filter
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 
@@ -132,10 +133,11 @@ func NewTriggerHandler(
 }
 
 // HandleMessage processes a NATS message, applies filter, and dispatches to subscriber.
-// With pull-based subscriptions, this is called synchronously from the fetch loop.
-func (h *TriggerHandler) HandleMessage(msg *nats.Msg) {
+// ctx should carry an AckWait deadline so that the outbound HTTP call is cancelled
+// before JetStream redelivers the message; use context.WithTimeout(parent, ackWait).
+func (h *TriggerHandler) HandleMessage(ctx context.Context, msg *nats.Msg) {
 	logger := h.logger.With(zap.String("msg_id", msg.Header.Get(nats.MsgIdHdr)))
-	ctx := logging.WithLogger(h.ctx, logger)
+	ctx = logging.WithLogger(ctx, logger)
 
 	h.doHandle(ctx, msg)
 }
@@ -189,7 +191,10 @@ func (h *TriggerHandler) doHandle(ctx context.Context, msg *nats.Msg) {
 	)
 
 	dispatchInfo, err := h.dispatchEvent(ctx, event, msg)
-	if err != nil {
+	if eventProcessingDeadlineExceeded(err) {
+		logger.Warnw("dispatch context expired before subscriber response, message will be redelivered by JetStream", zap.Error(err))
+		return
+	} else if err != nil {
 		logger.Errorw("failed to dispatch event",
 			zap.Error(err),
 			zap.Int("response_code", dispatchInfo.ResponseCode),
@@ -228,6 +233,13 @@ func (h *TriggerHandler) dispatchEvent(ctx context.Context, event *cloudevents.E
 		kncloudevents.WithTransformers(&te),
 		kncloudevents.WithRetryConfig(h.noRetryConfig),
 	)
+
+	// Context deadline/cancellation means the AckWait guard fired before we got
+	// a subscriber response. Don't ack/nack/term the message — JetStream will
+	// redeliver it automatically once its own AckWait timer expires.
+	if eventProcessingDeadlineExceeded(err) {
+		return dispatchInfo, err
+	}
 
 	result := determineNatsResult(dispatchInfo.ResponseCode, err)
 
@@ -311,6 +323,10 @@ func (h *TriggerHandler) dispatchEvent(ctx context.Context, event *cloudevents.E
 	}
 
 	return dispatchInfo, err
+}
+
+func eventProcessingDeadlineExceeded(err error) bool {
+	return err != nil && (errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled))
 }
 
 // responseToEvent parses the subscriber's HTTP response into a CloudEvent.

--- a/pkg/broker/filter/handler_message_test.go
+++ b/pkg/broker/filter/handler_message_test.go
@@ -1,0 +1,307 @@
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filter
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	cejs "github.com/cloudevents/sdk-go/protocol/nats_jetstream/v2"
+	"github.com/nats-io/nats.go"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/logging"
+
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+	"knative.dev/eventing/pkg/eventingtls"
+	"knative.dev/eventing/pkg/kncloudevents"
+)
+
+// makeStructuredCEMsg constructs a nats.Msg carrying a structured CloudEvent.
+// The message header contains "Content-Type: application/cloudevents+json"
+// so cejs.NewMessage returns EncodingStructured and the body is the CE JSON.
+func makeStructuredCEMsg(eventType, source, id string) *nats.Msg {
+	body := `{"specversion":"1.0","type":"` + eventType + `","source":"` + source + `","id":"` + id + `"}`
+	return &nats.Msg{
+		Subject: "test.subject",
+		Header:  nats.Header{"Content-Type": []string{"application/cloudevents+json"}},
+		Data:    []byte(body),
+	}
+}
+
+// makeTrigger builds a minimal trigger with an optional attribute filter.
+// filterType may be empty ("") to disable the attribute filter.
+func makeTrigger(namespace, name, filterType string) *eventingv1.Trigger {
+	t := &eventingv1.Trigger{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: eventingv1.TriggerSpec{
+			Broker: "test-broker",
+		},
+	}
+	if filterType != "" {
+		t.Spec.Filter = &eventingv1.TriggerFilter{
+			Attributes: map[string]string{"type": filterType},
+		}
+	}
+	return t
+}
+
+// newTestDispatcher creates a dispatcher suitable for unit tests.
+// Passing nil OIDC token provider is fine for tests — OIDC token injection
+// is only triggered when the destination requires it.
+func newTestDispatcher(_ context.Context) *kncloudevents.Dispatcher {
+	return kncloudevents.NewDispatcher(eventingtls.ClientConfig{}, nil)
+}
+
+// newTestHandler creates a TriggerHandler wired to the given subscriber URL.
+func newTestHandler(t *testing.T, ctx context.Context, subscriberURL string, filterType string) *TriggerHandler {
+	t.Helper()
+	u, err := apis.ParseURL(subscriberURL)
+	if err != nil {
+		t.Fatalf("ParseURL(%q): %v", subscriberURL, err)
+	}
+	subscriber := duckv1.Addressable{URL: u}
+	trigger := makeTrigger("default", "test-trigger", filterType)
+	dispatcher := newTestDispatcher(ctx)
+	h, err := NewTriggerHandler(ctx, trigger, subscriber, nil, nil, nil, nil, dispatcher)
+	if err != nil {
+		t.Fatalf("NewTriggerHandler: %v", err)
+	}
+	return h
+}
+
+// logCtx returns a context carrying a no-op zap logger.
+func logCtx() context.Context {
+	return logging.WithLogger(context.Background(), zap.NewNop().Sugar())
+}
+
+// TestHandleMessage_BadData verifies that a message with structured encoding
+// but unparseable data (no valid JSON) is terminated and the subscriber is not called.
+func TestHandleMessage_BadData(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx := logCtx()
+	handler := newTestHandler(t, ctx, srv.URL, "")
+
+	// Structured encoding with non-JSON body — cejs.NewMessage returns EncodingStructured
+	// but binding.ToEvent will fail to parse it. Handler calls msg.Term() and returns.
+	msg := &nats.Msg{
+		Subject: "test.subject",
+		Header:  nil, // nil header → EncodingStructured
+		Data:    []byte("not json at all"),
+	}
+
+	handler.HandleMessage(ctx, msg)
+
+	if called {
+		t.Error("subscriber should NOT be called when CE conversion fails")
+	}
+}
+
+// TestHandleMessage_FilteredOut verifies that a message whose event type does not
+// match the trigger filter is acked (not dispatched to the subscriber).
+func TestHandleMessage_FilteredOut(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx := logCtx()
+	// Trigger has filter for "other.type" but message is "test.type" — should be filtered out.
+	handler := newTestHandler(t, ctx, srv.URL, "other.type")
+
+	msg := makeStructuredCEMsg("test.type", "test/source", "test-id-1")
+	handler.HandleMessage(ctx, msg)
+
+	if called {
+		t.Error("subscriber should NOT be called for filtered-out messages")
+	}
+}
+
+// TestHandleMessage_Dispatch_Success verifies that 2xx responses cause a successful dispatch.
+func TestHandleMessage_Dispatch_Success(t *testing.T) {
+	codes := []int{http.StatusOK, http.StatusAccepted}
+	for _, code := range codes {
+		code := code
+		t.Run(http.StatusText(code), func(t *testing.T) {
+			var count int64
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				atomic.AddInt64(&count, 1)
+				w.WriteHeader(code)
+			}))
+			defer srv.Close()
+
+			ctx := logCtx()
+			handler := newTestHandler(t, ctx, srv.URL, "")
+
+			msg := makeStructuredCEMsg("test.type", "test/source", "test-id-2xx")
+			handler.HandleMessage(ctx, msg)
+
+			if got := atomic.LoadInt64(&count); got != 1 {
+				t.Errorf("subscriber called %d times, want 1", got)
+			}
+		})
+	}
+}
+
+// TestHandleMessage_Dispatch_RetriableError verifies that 5xx/429 responses
+// reach the subscriber and nack is attempted (fails gracefully without a real NATS conn).
+func TestHandleMessage_Dispatch_RetriableError(t *testing.T) {
+	codes := []int{
+		http.StatusInternalServerError,
+		http.StatusServiceUnavailable,
+		http.StatusTooManyRequests,
+	}
+	for _, code := range codes {
+		code := code
+		t.Run(http.StatusText(code), func(t *testing.T) {
+			var count int64
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				atomic.AddInt64(&count, 1)
+				w.WriteHeader(code)
+			}))
+			defer srv.Close()
+
+			ctx := logCtx()
+			handler := newTestHandler(t, ctx, srv.URL, "")
+
+			msg := makeStructuredCEMsg("test.type", "test/source", "test-id-5xx")
+			// NakWithDelay will fail with ErrMsgNoReply — handler logs and continues.
+			handler.HandleMessage(ctx, msg)
+
+			if got := atomic.LoadInt64(&count); got != 1 {
+				t.Errorf("subscriber called %d times, want 1", got)
+			}
+		})
+	}
+}
+
+// TestHandleMessage_Dispatch_NonRetriable verifies that 4xx responses
+// reach the subscriber and term is attempted (fails gracefully without a real NATS conn).
+func TestHandleMessage_Dispatch_NonRetriable(t *testing.T) {
+	codes := []int{
+		http.StatusBadRequest,
+		http.StatusForbidden,
+		http.StatusNotFound,
+	}
+	for _, code := range codes {
+		code := code
+		t.Run(http.StatusText(code), func(t *testing.T) {
+			var count int64
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				atomic.AddInt64(&count, 1)
+				w.WriteHeader(code)
+			}))
+			defer srv.Close()
+
+			ctx := logCtx()
+			handler := newTestHandler(t, ctx, srv.URL, "")
+
+			msg := makeStructuredCEMsg("test.type", "test/source", "test-id-4xx")
+			// Term will fail with ErrMsgNoReply — handler logs and continues.
+			handler.HandleMessage(ctx, msg)
+
+			if got := atomic.LoadInt64(&count); got != 1 {
+				t.Errorf("subscriber called %d times, want 1", got)
+			}
+		})
+	}
+}
+
+// TestHandleMessage_CancelledContext verifies that when the context is already
+// cancelled before HandleMessage, the dispatch is cancelled and no panic occurs.
+func TestHandleMessage_CancelledContext(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		// Block until context is done — simulates the cancelled case.
+		<-r.Context().Done()
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	ctx := logCtx()
+	handler := newTestHandler(t, ctx, srv.URL, "")
+
+	// Cancel the context before calling HandleMessage.
+	cancelCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	msg := makeStructuredCEMsg("test.type", "test/source", "test-id-cancelled")
+
+	// Should not panic; eventProcessingDeadlineExceeded fires and returns early.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler.HandleMessage(cancelCtx, msg)
+	}()
+
+	select {
+	case <-done:
+		// Good — no hang.
+	case <-time.After(5 * time.Second):
+		t.Fatal("HandleMessage did not return within 5 seconds with cancelled context")
+	}
+	_ = called // subscriber may or may not be called depending on timing; we just assert no hang
+}
+
+// TestTransform_NoType covers the branch where GetAttribute returns nil for the
+// CloudEvent type (e.g., the attribute is not set), so the inner if-block is skipped.
+// This covers the previously uncovered "ty == nil → skip" branch.
+func TestTransform_NoType(t *testing.T) {
+	// Use a cejs.Message wrapping a *nats.Msg with binary encoding but no ce-type header.
+	// ce-specversion present → binary encoding; ce-type absent → GetAttribute(spec.Type) returns nil.
+	msg := &nats.Msg{
+		Subject: "test.subject",
+		Header: nats.Header{
+			"Ce-Specversion": []string{"1.0"},
+			"Ce-Source":      []string{"test/source"},
+			"Ce-Id":          []string{"test-id-notype"},
+			// "Ce-Type" intentionally absent
+		},
+		Data: []byte(`{}`),
+	}
+
+	import_cejs := cejs.NewMessage(msg)
+
+	te := TypeExtractorTransformer("initial")
+	err := te.Transform(import_cejs, nil)
+	if err != nil {
+		t.Fatalf("Transform() unexpected error: %v", err)
+	}
+	// No type header → TypeExtractorTransformer should remain unchanged.
+	if string(te) != "initial" {
+		t.Errorf("TypeExtractorTransformer = %q, want %q (should be unchanged when type is absent)", string(te), "initial")
+	}
+}

--- a/pkg/broker/filter/handler_test.go
+++ b/pkg/broker/filter/handler_test.go
@@ -19,6 +19,7 @@ package filter
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -748,5 +749,53 @@ func TestDefaultRetryConfigInitialized(t *testing.T) {
 	}
 	if defaultRetry.Backoff == nil {
 		t.Error("defaultRetry.Backoff should not be nil")
+	}
+}
+
+func TestEventProcessingDeadlineExceeded(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error returns false",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "plain error returns false",
+			err:  errors.New("some error"),
+			want: false,
+		},
+		{
+			name: "context.DeadlineExceeded returns true",
+			err:  context.DeadlineExceeded,
+			want: true,
+		},
+		{
+			name: "context.Canceled returns true",
+			err:  context.Canceled,
+			want: true,
+		},
+		{
+			name: "wrapped DeadlineExceeded returns true",
+			err:  fmt.Errorf("wrap: %w", context.DeadlineExceeded),
+			want: true,
+		},
+		{
+			name: "wrapped Canceled returns true",
+			err:  fmt.Errorf("wrap: %w", context.Canceled),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := eventProcessingDeadlineExceeded(tt.err)
+			if got != tt.want {
+				t.Errorf("eventProcessingDeadlineExceeded(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Problem: Sequential Message Processing and No Backpressure Control

Root problem 1 — Sequential dispatch

The original fetchLoop processed messages one at a time:

```
for _, msg := range msgs {
    handler.HandleMessage(msg)  // blocks until HTTP response
}
``` 

Root problem 2 — AckWait redelivery duplicates

JetStream's AckWait clock starts when a message is delivered to the consumer (when Fetch() returns it). With sequential processing, messages later in a batch could not be acknowledged before AckWait expired. For example, with a batch of 10, AckWait of 30s, and a 4s subscriber:

- Message 8 is fetched at t=0, AckWait expires at t=30
- Sequential processing reaches message 8 at t=28 (7 × 4s), acks at t=32
- JetStream redelivers at t=30 — duplicate subscriber call

This consumed retry budget (MaxDeliver) on infrastructure lag rather than real failures.

Root problem 3 — No concurrency control

There was no mechanism to limit how many messages could be dispatched simultaneously. Adding concurrency naïvely (spawning a goroutine per message) would cause unbounded goroutine growth under high load.

Root problem 4 — No per-trigger isolation

A single ConsumerManager served all triggers in a broker. A slow trigger could affect the processing of all other triggers sharing the same filter pod.

---
What Was Changed

1. Concurrent dispatch with per-trigger counting semaphore (consumer.go)

The fetch loop was rewritten to dispatch messages concurrently. Each message gets its own goroutine, bounded by a per-trigger counting semaphore (chan struct{} of capacity
maxConcurrency). The semaphore is acquired before the goroutine is spawned, so the fetch loop itself stalls when all slots are occupied — leaving messages safely in the JetStream stream
with their AckWait clocks not yet running.

A sync.WaitGroup tracks in-flight goroutines and is drained (defer wg.Wait()) on shutdown, ensuring no goroutine is abandoned when a subscription is cancelled.

Each dispatch goroutine carries a context.WithTimeout(ctx, ackWait) deadline, so if the subscriber does not respond within JetStream's AckWait window the HTTP call is cancelled cleanly
rather than blocking the goroutine indefinitely.

2. Context deadline guard in the handler (handler.go)

HandleMessage was changed to accept a context.Context parameter (previously it used a stored h.ctx). A new eventProcessingDeadlineExceeded helper was added to distinguish context
cancellation/deadline from real subscriber errors in dispatchEvent. When the AckWait context expires, the function returns without calling msg.Ack/Nack/Term — JetStream redelivers the
message naturally, avoiding the previous behaviour where a timeout would hit the default branch and call msg.Term(), permanently dropping the event.

3. Dynamic batch sizing to eliminate AckWait misalignment (consumer.go)

A subtle race existed even with the semaphore: if fetchBatchSize > available slots, some messages in a batch were fetched (JetStream AckWait clock running) while waiting for a semaphore
slot. The AckWait context was created after acquiring the slot, giving those messages a full AckWait from dispatch time — later than JetStream's clock, causing JetStream to redeliver
before the context expired.

The fix: before each sub.Fetch() call, compute available = cap(sem) - len(sem) and cap the request to min(fetchBatchSize, available). Since fetchLoop is the only semaphore producer
(goroutines only release), available is a stable lower bound — it can only increase between the check and the semaphore acquire, never decrease. Every fetched message acquires its slot
within microseconds, keeping the AckWait context start time aligned with JetStream's delivery clock. When available == 0, the loop waits one fetchTimeout interval before re-checking,
leaving messages in the stream.

**Release Note**

```release-note
All three fetch parameters are now configurable independently per trigger via annotations, falling back to broker-wide defaults (set via env vars on the filter deployment), which fall
back to hardcoded constants:

┌─────────────────────────────────────────────────────┬───────────────────────────┬─────────┐
│                     Annotation                      │          Env var          │ Default │
├─────────────────────────────────────────────────────┼───────────────────────────┼─────────┤
│ natsjetstream.eventing.knative.dev/fetch-batch-size │ CONSUMER_FETCH_BATCH_SIZE │ 10      │
├─────────────────────────────────────────────────────┼───────────────────────────┼─────────┤
│ natsjetstream.eventing.knative.dev/fetch-timeout    │ CONSUMER_FETCH_TIMEOUT    │ 200ms   │
├─────────────────────────────────────────────────────┼───────────────────────────┼─────────┤
│ natsjetstream.eventing.knative.dev/max-concurrency  │ CONSUMER_MAX_CONCURRENCY  │ 20      │
└─────────────────────────────────────────────────────┴───────────────────────────┴─────────┘
```

