### PR TITLE
added missing tracing and new metrics

### DIFF
--- a/pkg/broker/filter/consumer.go
+++ b/pkg/broker/filter/consumer.go
@@ -25,6 +25,10 @@ import (
 	"time"
 
 	"github.com/nats-io/nats.go"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -37,6 +41,11 @@ import (
 
 	brokerutils "knative.dev/eventing-natss/pkg/broker/utils"
 )
+
+// otelScope is the OTel instrumentation scope used for the broker filter's
+// tracer and meter. Channel parity: dispatch.duration histogram is named the
+// same as the channel's (kn.eventing.dispatch.duration) so they aggregate.
+const otelScope = "knative.dev/eventing-natss/pkg/broker/filter"
 
 const (
 	// DefaultFetchBatchSize is the default number of messages to fetch in each batch
@@ -104,6 +113,12 @@ type ConsumerManager struct {
 	// Event dispatcher
 	dispatcher *kncloudevents.Dispatcher
 
+	// Observability instruments. Resolved from the global OTel providers in
+	// NewConsumerManager; passed to each TriggerHandler. The inflight gauge
+	// is registered once and walks m.subscriptions on each collection cycle.
+	tracer           trace.Tracer
+	dispatchDuration metric.Float64Histogram
+
 	// Map of trigger UID to subscription
 	subscriptions map[string]*TriggerSubscription
 	mu            sync.RWMutex
@@ -149,6 +164,8 @@ type TriggerSubscription struct {
 
 // NewConsumerManager creates a new consumer manager
 func NewConsumerManager(ctx context.Context, conn *nats.Conn, js nats.JetStreamContext, config *ConsumerManagerConfig) *ConsumerManager {
+	logger := logging.FromContext(ctx)
+
 	// Create OIDC token provider and dispatcher
 	oidcTokenProvider := auth.NewOIDCTokenProvider(ctx)
 	dispatcher := kncloudevents.NewDispatcher(eventingtls.ClientConfig{}, oidcTokenProvider)
@@ -170,8 +187,23 @@ func NewConsumerManager(ctx context.Context, conn *nats.Conn, js nats.JetStreamC
 		}
 	}
 
-	return &ConsumerManager{
-		logger:                logging.FromContext(ctx),
+	// Resolve tracer + meter from the global OTel providers. When no real
+	// provider is registered these are no-ops, so this is safe to call
+	// unconditionally regardless of how the host wires observability.
+	tracer := otel.GetTracerProvider().Tracer(otelScope)
+	meter := otel.GetMeterProvider().Meter(otelScope)
+	dispatchDuration, err := meter.Float64Histogram(
+		"kn.eventing.dispatch.duration",
+		metric.WithDescription("The duration to dispatch the event"),
+		metric.WithUnit("s"),
+	)
+	if err != nil {
+		logger.Warnw("failed to create dispatch duration histogram; metric will be skipped", zap.Error(err))
+		dispatchDuration = nil
+	}
+
+	cm := &ConsumerManager{
+		logger:                logger,
 		ctx:                   ctx,
 		js:                    js,
 		conn:                  conn,
@@ -179,8 +211,34 @@ func NewConsumerManager(ctx context.Context, conn *nats.Conn, js nats.JetStreamC
 		fetchTimeout:          fetchTimeout,
 		defaultMaxConcurrency: maxConcurrency,
 		dispatcher:            dispatcher,
+		tracer:                tracer,
+		dispatchDuration:      dispatchDuration,
 		subscriptions:         make(map[string]*TriggerSubscription),
 	}
+
+	// Observable gauge: in-flight dispatches per trigger. len(sem) is the
+	// number of currently-held semaphore slots, which equals the number of
+	// dispatch goroutines this trigger has in flight. Read under m.mu so the
+	// subscription map is stable while the callback iterates.
+	if _, err := meter.Int64ObservableGauge(
+		"kn.eventing.broker.filter.dispatches.inflight",
+		metric.WithDescription("Current number of in-flight dispatch goroutines per trigger"),
+		metric.WithInt64Callback(func(_ context.Context, obs metric.Int64Observer) error {
+			cm.mu.RLock()
+			defer cm.mu.RUnlock()
+			for _, sub := range cm.subscriptions {
+				obs.Observe(int64(len(sub.sem)), metric.WithAttributes(
+					attribute.String("trigger.name", sub.trigger.Name),
+					attribute.String("trigger.namespace", sub.trigger.Namespace),
+				))
+			}
+			return nil
+		}),
+	); err != nil {
+		logger.Warnw("failed to register inflight observable gauge; metric will be skipped", zap.Error(err))
+	}
+
+	return cm
 }
 
 // parseTriggerAnnotationInt reads key from annotations as a positive int,
@@ -309,6 +367,8 @@ func (m *ConsumerManager) SubscribeTrigger(
 		retryConfig,
 		noRetryConfig,
 		m.dispatcher,
+		m.tracer,
+		m.dispatchDuration,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create trigger handler: %w", err)

--- a/pkg/broker/filter/consumer.go
+++ b/pkg/broker/filter/consumer.go
@@ -47,6 +47,12 @@ import (
 // same as the channel's (kn.eventing.dispatch.duration) so they aggregate.
 const otelScope = "knative.dev/eventing-natss/pkg/broker/filter"
 
+// latencyBounds are the explicit histogram bucket boundaries (in seconds) for
+// the dispatch.duration metric. They must match upstream eventing's channel
+// dispatcher (pkg/channel/fanout) so the shared kn.eventing.dispatch.duration
+// metric aggregates cleanly across channels and brokers.
+var latencyBounds = []float64{0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10}
+
 const (
 	// DefaultFetchBatchSize is the default number of messages to fetch in each batch
 	DefaultFetchBatchSize = 10
@@ -118,6 +124,7 @@ type ConsumerManager struct {
 	// is registered once and walks m.subscriptions on each collection cycle.
 	tracer           trace.Tracer
 	dispatchDuration metric.Float64Histogram
+	processDuration  metric.Float64Histogram
 
 	// Map of trigger UID to subscription
 	subscriptions map[string]*TriggerSubscription
@@ -196,10 +203,22 @@ func NewConsumerManager(ctx context.Context, conn *nats.Conn, js nats.JetStreamC
 		"kn.eventing.dispatch.duration",
 		metric.WithDescription("The duration to dispatch the event"),
 		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(latencyBounds...),
 	)
 	if err != nil {
 		logger.Warnw("failed to create dispatch duration histogram; metric will be skipped", zap.Error(err))
 		dispatchDuration = nil
+	}
+
+	processDuration, err := meter.Float64Histogram(
+		"kn.eventing.broker.filter.process.duration",
+		metric.WithDescription("The duration of pre-dispatch processing (message decode and filter evaluation)"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(latencyBounds...),
+	)
+	if err != nil {
+		logger.Warnw("failed to create process duration histogram; metric will be skipped", zap.Error(err))
+		processDuration = nil
 	}
 
 	cm := &ConsumerManager{
@@ -213,6 +232,7 @@ func NewConsumerManager(ctx context.Context, conn *nats.Conn, js nats.JetStreamC
 		dispatcher:            dispatcher,
 		tracer:                tracer,
 		dispatchDuration:      dispatchDuration,
+		processDuration:       processDuration,
 		subscriptions:         make(map[string]*TriggerSubscription),
 	}
 
@@ -228,8 +248,8 @@ func NewConsumerManager(ctx context.Context, conn *nats.Conn, js nats.JetStreamC
 			defer cm.mu.RUnlock()
 			for _, sub := range cm.subscriptions {
 				obs.Observe(int64(len(sub.sem)), metric.WithAttributes(
-					attribute.String("trigger.name", sub.trigger.Name),
-					attribute.String("trigger.namespace", sub.trigger.Namespace),
+					attribute.String("kn.trigger.name", sub.trigger.Name),
+					attribute.String("kn.trigger.namespace", sub.trigger.Namespace),
 				))
 			}
 			return nil
@@ -369,6 +389,7 @@ func (m *ConsumerManager) SubscribeTrigger(
 		m.dispatcher,
 		m.tracer,
 		m.dispatchDuration,
+		m.processDuration,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create trigger handler: %w", err)

--- a/pkg/broker/filter/consumer_nats_test.go
+++ b/pkg/broker/filter/consumer_nats_test.go
@@ -1032,8 +1032,14 @@ func TestObservability_SpanAndMetricsEmitted(t *testing.T) {
 	if attrs["kn.trigger.namespace"] != namespace {
 		t.Errorf("span kn.trigger.namespace = %q, want %q", attrs["kn.trigger.namespace"], namespace)
 	}
-	if attrs["ce.id"] != "obs-event-id" {
-		t.Errorf("span ce.id = %q, want %q", attrs["ce.id"], "obs-event-id")
+	if attrs["cloudevents.event.id"] != "obs-event-id" {
+		t.Errorf("span cloudevents.event.id = %q, want %q", attrs["cloudevents.event.id"], "obs-event-id")
+	}
+	if attrs["cloudevents.event.type"] != "test.type" {
+		t.Errorf("span cloudevents.event.type = %q, want %q", attrs["cloudevents.event.type"], "test.type")
+	}
+	if attrs["cloudevents.event.source"] != "test/source" {
+		t.Errorf("span cloudevents.event.source = %q, want %q", attrs["cloudevents.event.source"], "test/source")
 	}
 	if attrs["nats.result"] != "ack" {
 		t.Errorf("span nats.result = %q, want %q", attrs["nats.result"], "ack")

--- a/pkg/broker/filter/consumer_nats_test.go
+++ b/pkg/broker/filter/consumer_nats_test.go
@@ -974,8 +974,8 @@ func TestObservability_SpanAndMetricsEmitted(t *testing.T) {
 			defer cm.mu.RUnlock()
 			for _, sub := range cm.subscriptions {
 				obs.Observe(int64(len(sub.sem)), otelmetric.WithAttributes(
-					attribute.String("trigger.name", sub.trigger.Name),
-					attribute.String("trigger.namespace", sub.trigger.Namespace),
+					attribute.String("kn.trigger.name", sub.trigger.Name),
+					attribute.String("kn.trigger.namespace", sub.trigger.Namespace),
 				))
 			}
 			return nil

--- a/pkg/broker/filter/consumer_nats_test.go
+++ b/pkg/broker/filter/consumer_nats_test.go
@@ -26,6 +26,13 @@ import (
 	"time"
 
 	"github.com/nats-io/nats.go"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -107,6 +114,8 @@ func makeTriggerWithUID(namespace, name, brokerName, uid string) *eventingv1.Tri
 }
 
 // newConsumerManagerForTest creates a ConsumerManager with a real NATS connection.
+// Mirrors NewConsumerManager's observability bootstrap (tracer, dispatch-duration
+// histogram, in-flight observable gauge) so tests exercise the same code path.
 func newConsumerManagerForTest(t *testing.T, ctx context.Context, conn *nats.Conn, js nats.JetStreamContext, cfg *ConsumerManagerConfig) *ConsumerManager {
 	t.Helper()
 	dispatcher := kncloudevents.NewDispatcher(eventingtls.ClientConfig{}, nil)
@@ -127,7 +136,17 @@ func newConsumerManagerForTest(t *testing.T, ctx context.Context, conn *nats.Con
 		}
 	}
 
-	return &ConsumerManager{
+	tracer := otel.GetTracerProvider().Tracer("knative.dev/eventing-natss/pkg/broker/filter")
+	meter := otel.GetMeterProvider().Meter("knative.dev/eventing-natss/pkg/broker/filter")
+	dispatchDuration, err := meter.Float64Histogram(
+		"kn.eventing.dispatch.duration",
+		otelmetric.WithUnit("s"),
+	)
+	if err != nil {
+		t.Fatalf("create dispatch duration histogram: %v", err)
+	}
+
+	cm := &ConsumerManager{
 		logger:                logging.FromContext(ctx),
 		ctx:                   ctx,
 		js:                    js,
@@ -136,8 +155,29 @@ func newConsumerManagerForTest(t *testing.T, ctx context.Context, conn *nats.Con
 		fetchTimeout:          fetchTimeout,
 		defaultMaxConcurrency: maxConcurrency,
 		dispatcher:            dispatcher,
+		tracer:                tracer,
+		dispatchDuration:      dispatchDuration,
 		subscriptions:         make(map[string]*TriggerSubscription),
 	}
+
+	if _, err := meter.Int64ObservableGauge(
+		"kn.eventing.broker.filter.dispatches.inflight",
+		otelmetric.WithInt64Callback(func(_ context.Context, obs otelmetric.Int64Observer) error {
+			cm.mu.RLock()
+			defer cm.mu.RUnlock()
+			for _, sub := range cm.subscriptions {
+				obs.Observe(int64(len(sub.sem)), otelmetric.WithAttributes(
+					attribute.String("trigger.name", sub.trigger.Name),
+					attribute.String("trigger.namespace", sub.trigger.Namespace),
+				))
+			}
+			return nil
+		}),
+	); err != nil {
+		t.Fatalf("register inflight observable gauge: %v", err)
+	}
+
+	return cm
 }
 
 // publishStructuredCE publishes a structured CloudEvent to the given subject.
@@ -838,6 +878,177 @@ func TestSubscribeTrigger_RestartTriggers(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestObservability_SpanAndMetricsEmitted verifies that the broker filter
+// produces (1) a "broker.filter.dispatch" span per dispatch with the expected
+// attributes, (2) a kn.eventing.dispatch.duration histogram observation, and
+// (3) a kn.eventing.broker.filter.dispatches.inflight observable gauge that
+// can be collected. The MeterProvider and TracerProvider are constructed
+// locally and injected directly into the ConsumerManager — we deliberately
+// avoid otel.SetMeterProvider because the OTel global's delegate retains
+// instrument registrations from earlier tests in the same package, which
+// would prevent our callback from being collected.
+func TestObservability_SpanAndMetricsEmitted(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	spanExporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(spanExporter))
+
+	s := natsTesting.RunBasicJetstreamServer()
+	defer natsTesting.ShutdownJSServerAndRemoveStorage(t, s)
+	conn, js := natsTesting.JsClient(t, s)
+	defer conn.Close()
+
+	ctx := logging.WithLogger(context.Background(), zap.NewNop().Sugar())
+
+	namespace := "default"
+	brokerName := "obs-broker"
+	triggerUID := "obs-trigger-uid-001"
+
+	setupStreamAndConsumer(t, js, namespace, brokerName, triggerUID)
+
+	received := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case received <- struct{}{}:
+		default:
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Build a ConsumerManager directly bound to the local providers — no
+	// otel.Set* dance. This also keeps the test parallel-safe in principle.
+	meter := mp.Meter("knative.dev/eventing-natss/pkg/broker/filter")
+	tracer := tp.Tracer("knative.dev/eventing-natss/pkg/broker/filter")
+	dispatchDuration, err := meter.Float64Histogram(
+		"kn.eventing.dispatch.duration",
+		otelmetric.WithUnit("s"),
+	)
+	if err != nil {
+		t.Fatalf("create dispatch histogram: %v", err)
+	}
+
+	cm := &ConsumerManager{
+		logger:                logging.FromContext(ctx),
+		ctx:                   ctx,
+		js:                    js,
+		conn:                  conn,
+		fetchBatchSize:        1,
+		fetchTimeout:          100 * time.Millisecond,
+		defaultMaxConcurrency: 4,
+		dispatcher:            kncloudevents.NewDispatcher(eventingtls.ClientConfig{}, nil),
+		tracer:                tracer,
+		dispatchDuration:      dispatchDuration,
+		subscriptions:         make(map[string]*TriggerSubscription),
+	}
+	defer cm.Close() //nolint:errcheck
+
+	if _, err := meter.Int64ObservableGauge(
+		"kn.eventing.broker.filter.dispatches.inflight",
+		otelmetric.WithInt64Callback(func(_ context.Context, obs otelmetric.Int64Observer) error {
+			cm.mu.RLock()
+			defer cm.mu.RUnlock()
+			for _, sub := range cm.subscriptions {
+				obs.Observe(int64(len(sub.sem)), otelmetric.WithAttributes(
+					attribute.String("trigger.name", sub.trigger.Name),
+					attribute.String("trigger.namespace", sub.trigger.Namespace),
+				))
+			}
+			return nil
+		}),
+	); err != nil {
+		t.Fatalf("register inflight gauge: %v", err)
+	}
+
+	broker := makeTestBrokerForNats(namespace, brokerName)
+	trigger := makeTriggerWithUID(namespace, "obs-trigger", brokerName, triggerUID)
+	subscriberURL, _ := apis.ParseURL(srv.URL)
+	subscriber := duckv1.Addressable{URL: subscriberURL}
+
+	if err := cm.SubscribeTrigger(trigger, broker, subscriber, nil, nil, nil, nil); err != nil {
+		t.Fatalf("SubscribeTrigger: %v", err)
+	}
+
+	publishSubject := brokerutils.BrokerPublishSubjectName(namespace, brokerName)
+	publishStructuredCE(t, js, publishSubject, "obs-event-id")
+
+	select {
+	case <-received:
+	case <-time.After(5 * time.Second):
+		t.Fatal("subscriber never received the dispatched event")
+	}
+
+	// Allow span/metric records to flush. Spans are synchronous via WithSyncer;
+	// histogram records are synchronous via ManualReader.
+	deadline := time.Now().Add(2 * time.Second)
+	var dispatchSpan *tracetest.SpanStub
+	for time.Now().Before(deadline) {
+		for i, s := range spanExporter.GetSpans() {
+			if s.Name == "broker.filter.dispatch" {
+				dispatchSpan = &spanExporter.GetSpans()[i]
+				break
+			}
+		}
+		if dispatchSpan != nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if dispatchSpan == nil {
+		t.Fatal("broker.filter.dispatch span was not recorded")
+	}
+
+	attrs := map[string]string{}
+	for _, a := range dispatchSpan.Attributes {
+		attrs[string(a.Key)] = a.Value.AsString()
+	}
+	if attrs["trigger.name"] != "obs-trigger" {
+		t.Errorf("span trigger.name = %q, want %q", attrs["trigger.name"], "obs-trigger")
+	}
+	if attrs["trigger.namespace"] != namespace {
+		t.Errorf("span trigger.namespace = %q, want %q", attrs["trigger.namespace"], namespace)
+	}
+	if attrs["ce.id"] != "obs-event-id" {
+		t.Errorf("span ce.id = %q, want %q", attrs["ce.id"], "obs-event-id")
+	}
+	if attrs["nats.result"] != "ack" {
+		t.Errorf("span nats.result = %q, want %q", attrs["nats.result"], "ack")
+	}
+
+	// Collect metrics. ManualReader.Collect populates rm in place.
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("metric reader Collect: %v", err)
+	}
+
+	var sawDuration, sawInflight bool
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			switch m.Name {
+			case "kn.eventing.dispatch.duration":
+				if h, ok := m.Data.(metricdata.Histogram[float64]); ok && len(h.DataPoints) > 0 {
+					sawDuration = true
+				}
+			case "kn.eventing.broker.filter.dispatches.inflight":
+				if g, ok := m.Data.(metricdata.Gauge[int64]); ok && len(g.DataPoints) >= 0 {
+					// Even with zero in-flight at collection time the gauge is
+					// considered registered as long as the callback ran without
+					// error; the data points slice may be empty if no subscriptions
+					// exist, but in this test we do have one.
+					sawInflight = true
+				}
+			}
+		}
+	}
+	if !sawDuration {
+		t.Error("kn.eventing.dispatch.duration histogram had no data points")
+	}
+	if !sawInflight {
+		t.Error("kn.eventing.broker.filter.dispatches.inflight gauge was not collected")
 	}
 }
 

--- a/pkg/broker/filter/consumer_nats_test.go
+++ b/pkg/broker/filter/consumer_nats_test.go
@@ -141,9 +141,18 @@ func newConsumerManagerForTest(t *testing.T, ctx context.Context, conn *nats.Con
 	dispatchDuration, err := meter.Float64Histogram(
 		"kn.eventing.dispatch.duration",
 		otelmetric.WithUnit("s"),
+		otelmetric.WithExplicitBucketBoundaries(latencyBounds...),
 	)
 	if err != nil {
 		t.Fatalf("create dispatch duration histogram: %v", err)
+	}
+	processDuration, err := meter.Float64Histogram(
+		"kn.eventing.broker.filter.process.duration",
+		otelmetric.WithUnit("s"),
+		otelmetric.WithExplicitBucketBoundaries(latencyBounds...),
+	)
+	if err != nil {
+		t.Fatalf("create process duration histogram: %v", err)
 	}
 
 	cm := &ConsumerManager{
@@ -157,6 +166,7 @@ func newConsumerManagerForTest(t *testing.T, ctx context.Context, conn *nats.Con
 		dispatcher:            dispatcher,
 		tracer:                tracer,
 		dispatchDuration:      dispatchDuration,
+		processDuration:       processDuration,
 		subscriptions:         make(map[string]*TriggerSubscription),
 	}
 
@@ -167,8 +177,8 @@ func newConsumerManagerForTest(t *testing.T, ctx context.Context, conn *nats.Con
 			defer cm.mu.RUnlock()
 			for _, sub := range cm.subscriptions {
 				obs.Observe(int64(len(sub.sem)), otelmetric.WithAttributes(
-					attribute.String("trigger.name", sub.trigger.Name),
-					attribute.String("trigger.namespace", sub.trigger.Namespace),
+					attribute.String("kn.trigger.name", sub.trigger.Name),
+					attribute.String("kn.trigger.namespace", sub.trigger.Namespace),
 				))
 			}
 			return nil
@@ -927,9 +937,18 @@ func TestObservability_SpanAndMetricsEmitted(t *testing.T) {
 	dispatchDuration, err := meter.Float64Histogram(
 		"kn.eventing.dispatch.duration",
 		otelmetric.WithUnit("s"),
+		otelmetric.WithExplicitBucketBoundaries(latencyBounds...),
 	)
 	if err != nil {
 		t.Fatalf("create dispatch histogram: %v", err)
+	}
+	processDuration, err := meter.Float64Histogram(
+		"kn.eventing.broker.filter.process.duration",
+		otelmetric.WithUnit("s"),
+		otelmetric.WithExplicitBucketBoundaries(latencyBounds...),
+	)
+	if err != nil {
+		t.Fatalf("create process histogram: %v", err)
 	}
 
 	cm := &ConsumerManager{
@@ -943,6 +962,7 @@ func TestObservability_SpanAndMetricsEmitted(t *testing.T) {
 		dispatcher:            kncloudevents.NewDispatcher(eventingtls.ClientConfig{}, nil),
 		tracer:                tracer,
 		dispatchDuration:      dispatchDuration,
+		processDuration:       processDuration,
 		subscriptions:         make(map[string]*TriggerSubscription),
 	}
 	defer cm.Close() //nolint:errcheck
@@ -1025,13 +1045,17 @@ func TestObservability_SpanAndMetricsEmitted(t *testing.T) {
 		t.Fatalf("metric reader Collect: %v", err)
 	}
 
-	var sawDuration, sawInflight bool
+	var sawDuration, sawProcess, sawInflight bool
 	for _, sm := range rm.ScopeMetrics {
 		for _, m := range sm.Metrics {
 			switch m.Name {
 			case "kn.eventing.dispatch.duration":
 				if h, ok := m.Data.(metricdata.Histogram[float64]); ok && len(h.DataPoints) > 0 {
 					sawDuration = true
+				}
+			case "kn.eventing.broker.filter.process.duration":
+				if h, ok := m.Data.(metricdata.Histogram[float64]); ok && len(h.DataPoints) > 0 {
+					sawProcess = true
 				}
 			case "kn.eventing.broker.filter.dispatches.inflight":
 				if g, ok := m.Data.(metricdata.Gauge[int64]); ok && len(g.DataPoints) >= 0 {
@@ -1046,6 +1070,9 @@ func TestObservability_SpanAndMetricsEmitted(t *testing.T) {
 	}
 	if !sawDuration {
 		t.Error("kn.eventing.dispatch.duration histogram had no data points")
+	}
+	if !sawProcess {
+		t.Error("kn.eventing.broker.filter.process.duration histogram had no data points")
 	}
 	if !sawInflight {
 		t.Error("kn.eventing.broker.filter.dispatches.inflight gauge was not collected")

--- a/pkg/broker/filter/consumer_nats_test.go
+++ b/pkg/broker/filter/consumer_nats_test.go
@@ -1026,11 +1026,11 @@ func TestObservability_SpanAndMetricsEmitted(t *testing.T) {
 	for _, a := range dispatchSpan.Attributes {
 		attrs[string(a.Key)] = a.Value.AsString()
 	}
-	if attrs["trigger.name"] != "obs-trigger" {
-		t.Errorf("span trigger.name = %q, want %q", attrs["trigger.name"], "obs-trigger")
+	if attrs["kn.trigger.name"] != "obs-trigger" {
+		t.Errorf("span kn.trigger.name = %q, want %q", attrs["kn.trigger.name"], "obs-trigger")
 	}
-	if attrs["trigger.namespace"] != namespace {
-		t.Errorf("span trigger.namespace = %q, want %q", attrs["trigger.namespace"], namespace)
+	if attrs["kn.trigger.namespace"] != namespace {
+		t.Errorf("span kn.trigger.namespace = %q, want %q", attrs["kn.trigger.namespace"], namespace)
 	}
 	if attrs["ce.id"] != "obs-event-id" {
 		t.Errorf("span ce.id = %q, want %q", attrs["ce.id"], "obs-event-id")

--- a/pkg/broker/filter/handler.go
+++ b/pkg/broker/filter/handler.go
@@ -31,6 +31,11 @@ import (
 	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
 	"github.com/cloudevents/sdk-go/v2/types"
 	"github.com/nats-io/nats.go"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -100,6 +105,11 @@ type TriggerHandler struct {
 	deadLetterSink *duckv1.Addressable
 
 	subscription *nats.Subscription
+
+	// Observability. tracer is used to wrap each dispatch in a span;
+	// dispatchDuration records the per-dispatch HTTP wall time.
+	tracer           trace.Tracer
+	dispatchDuration metric.Float64Histogram
 }
 
 // NewTriggerHandler creates a new handler for a trigger
@@ -112,11 +122,20 @@ func NewTriggerHandler(
 	retryConfig *kncloudevents.RetryConfig,
 	noRetryConfig *kncloudevents.RetryConfig,
 	dispatcher *kncloudevents.Dispatcher,
+	tracer trace.Tracer,
+	dispatchDuration metric.Float64Histogram,
 ) (*TriggerHandler, error) {
 	logger := logging.FromContext(ctx).With(
 		zap.String("trigger", trigger.Name),
 		zap.String("namespace", trigger.Namespace),
 	)
+
+	// Fall back to the global tracer if none was provided, matching
+	// kncloudevents.NewDispatcher's behavior. dispatchDuration is allowed to
+	// stay nil — the histogram record sites already guard.
+	if tracer == nil {
+		tracer = otel.GetTracerProvider().Tracer("knative.dev/eventing-natss/pkg/broker/filter")
+	}
 
 	return &TriggerHandler{
 		logger:           logger,
@@ -129,6 +148,8 @@ func NewTriggerHandler(
 		retryConfig:      retryConfig,
 		noRetryConfig:    noRetryConfig,
 		deadLetterSink:   deadLetterSink,
+		tracer:           tracer,
+		dispatchDuration: dispatchDuration,
 	}, nil
 }
 
@@ -166,10 +187,28 @@ func (h *TriggerHandler) doHandle(ctx context.Context, msg *nats.Msg) {
 		return
 	}
 
+	// Adopt the producer's trace context from the CloudEvent extensions and
+	// start a span that covers filter eval + dispatch + ack/nak/term. Using a
+	// stable span name keeps trace-UI aggregation usable; per-trigger details
+	// live in attributes so they can be filtered without fragmenting names.
+	ctx = tracing.ParseSpanContext(ctx, event)
+	ctx, span := h.tracer.Start(ctx, "broker.filter.dispatch")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("trigger.name", h.trigger.Name),
+		attribute.String("trigger.namespace", h.trigger.Namespace),
+		attribute.String("trigger.uid", string(h.trigger.UID)),
+		attribute.String("subscriber.url", h.subscriber.URL.String()),
+		attribute.String("ce.id", event.ID()),
+		attribute.String("ce.type", event.Type()),
+		attribute.String("ce.source", event.Source()),
+	)
+
 	// Apply filter
 	if h.filter != nil {
 		filterResult := h.filter.Filter(ctx, *event)
 		if filterResult == eventfilter.FailFilter {
+			span.SetAttributes(attribute.String("filter.outcome", "fail"))
 			logger.Debugw("event filtered out",
 				zap.String("type", event.Type()),
 				zap.String("source", event.Source()),
@@ -180,6 +219,7 @@ func (h *TriggerHandler) doHandle(ctx context.Context, msg *nats.Msg) {
 			}
 			return
 		}
+		span.SetAttributes(attribute.String("filter.outcome", "pass"))
 	}
 
 	// Dispatch to subscriber
@@ -191,10 +231,16 @@ func (h *TriggerHandler) doHandle(ctx context.Context, msg *nats.Msg) {
 	)
 
 	dispatchInfo, err := h.dispatchEvent(ctx, event, msg)
+	if dispatchInfo != nil && dispatchInfo.ResponseCode != 0 {
+		span.SetAttributes(attribute.Int("http.response.status_code", dispatchInfo.ResponseCode))
+	}
 	if eventProcessingDeadlineExceeded(err) {
+		span.SetStatus(codes.Error, "dispatch deadline exceeded")
 		logger.Warnw("dispatch context expired before subscriber response, message will be redelivered by JetStream", zap.Error(err))
 		return
 	} else if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		logger.Errorw("failed to dispatch event",
 			zap.Error(err),
 			zap.Int("response_code", dispatchInfo.ResponseCode),
@@ -234,6 +280,17 @@ func (h *TriggerHandler) dispatchEvent(ctx context.Context, event *cloudevents.E
 		kncloudevents.WithRetryConfig(h.noRetryConfig),
 	)
 
+	// Record HTTP wall time with low-cardinality labels. Duration is left at
+	// kncloudevents.NoDuration (-1) when the request never made it onto the
+	// wire (e.g. request build / client creation failure); skip those.
+	if h.dispatchDuration != nil && dispatchInfo != nil && dispatchInfo.Duration >= 0 {
+		h.dispatchDuration.Record(ctx, dispatchInfo.Duration.Seconds(),
+			metric.WithAttributes(
+				attribute.String("trigger.name", h.trigger.Name),
+				attribute.String("trigger.namespace", h.trigger.Namespace),
+			))
+	}
+
 	// Context deadline/cancellation means the AckWait guard fired before we got
 	// a subscriber response. Don't ack/nack/term the message — JetStream will
 	// redeliver it automatically once its own AckWait timer expires.
@@ -247,9 +304,17 @@ func (h *TriggerHandler) dispatchEvent(ctx context.Context, event *cloudevents.E
 	// the subscriber's response so they are available in every code path.
 	responseHeaders := eventingutils.PassThroughHeaders(dispatchInfo.ResponseHeader)
 
+	// Decorate the active span with the delivery attempt. The span was started
+	// in doHandle; SpanFromContext returns the same one. Per-branch nats.result
+	// is set inside the switch so each label reflects the path actually taken
+	// (e.g. NACK on lastTry with no DLS does NOT visit the dead-letter sink).
+	span := trace.SpanFromContext(ctx)
+	span.SetAttributes(attribute.Int("delivery.attempt", retryNumber))
+
 	// Handle ack/nack/term based on result
 	switch {
 	case protocol.IsACK(result):
+		span.SetAttributes(attribute.String("nats.result", "ack"))
 		// If the subscriber returned a CloudEvent response, forward it to broker ingress for re-routing.
 		if h.brokerIngressURL != nil {
 			responseEvent, parseErr := responseToEvent(ctx, dispatchInfo)
@@ -287,6 +352,9 @@ func (h *TriggerHandler) dispatchEvent(ctx context.Context, event *cloudevents.E
 						zap.Int("response_code", dlsDispatchInfo.ResponseCode),
 					)
 				}
+				span.SetAttributes(attribute.String("nats.result", "ack_after_dls"))
+			} else {
+				span.SetAttributes(attribute.String("nats.result", "ack_retries_exhausted"))
 			}
 
 			// Ack after DLS attempt
@@ -294,6 +362,7 @@ func (h *TriggerHandler) dispatchEvent(ctx context.Context, event *cloudevents.E
 				logger.Errorw("failed to ack message after last retry", zap.Error(err))
 			}
 		} else {
+			span.SetAttributes(attribute.String("nats.result", "nak"))
 			// Nack for retry
 			nakDelay := jsutils.CalculateNakDelayForRetryNumber(retryNumber, h.retryConfig)
 			if err := msg.NakWithDelay(nakDelay, nats.Context(ctx)); err != nil {
@@ -315,6 +384,9 @@ func (h *TriggerHandler) dispatchEvent(ctx context.Context, event *cloudevents.E
 					zap.Int("response_code", dlsDispatchInfo.ResponseCode),
 				)
 			}
+			span.SetAttributes(attribute.String("nats.result", "term_after_dls"))
+		} else {
+			span.SetAttributes(attribute.String("nats.result", "term"))
 		}
 
 		if err := msg.Term(nats.Context(ctx)); err != nil {

--- a/pkg/broker/filter/handler.go
+++ b/pkg/broker/filter/handler.go
@@ -225,9 +225,9 @@ func (h *TriggerHandler) doHandle(ctx context.Context, msg *nats.Msg) {
 		attribute.String("kn.trigger.namespace", h.trigger.Namespace),
 		attribute.String("kn.trigger.uid", string(h.trigger.UID)),
 		attribute.String("messaging.destination.name", h.subscriber.URL.String()),
-		attribute.String("ce.id", event.ID()),
-		attribute.String("ce.type", event.Type()),
-		attribute.String("ce.source", event.Source()),
+		attribute.String("cloudevents.event.id", event.ID()),
+		attribute.String("cloudevents.event.type", event.Type()),
+		attribute.String("cloudevents.event.source", event.Source()),
 	)
 
 	// Apply filter

--- a/pkg/broker/filter/handler.go
+++ b/pkg/broker/filter/handler.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"time"
 
 	cejs "github.com/cloudevents/sdk-go/protocol/nats_jetstream/v2"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -107,9 +108,11 @@ type TriggerHandler struct {
 	subscription *nats.Subscription
 
 	// Observability. tracer is used to wrap each dispatch in a span;
-	// dispatchDuration records the per-dispatch HTTP wall time.
+	// dispatchDuration records the per-dispatch HTTP wall time; processDuration
+	// records the pre-dispatch work (message decode + filter evaluation).
 	tracer           trace.Tracer
 	dispatchDuration metric.Float64Histogram
+	processDuration  metric.Float64Histogram
 }
 
 // NewTriggerHandler creates a new handler for a trigger
@@ -124,6 +127,7 @@ func NewTriggerHandler(
 	dispatcher *kncloudevents.Dispatcher,
 	tracer trace.Tracer,
 	dispatchDuration metric.Float64Histogram,
+	processDuration metric.Float64Histogram,
 ) (*TriggerHandler, error) {
 	logger := logging.FromContext(ctx).With(
 		zap.String("trigger", trigger.Name),
@@ -150,6 +154,7 @@ func NewTriggerHandler(
 		deadLetterSink:   deadLetterSink,
 		tracer:           tracer,
 		dispatchDuration: dispatchDuration,
+		processDuration:  processDuration,
 	}, nil
 }
 
@@ -166,6 +171,27 @@ func (h *TriggerHandler) HandleMessage(ctx context.Context, msg *nats.Msg) {
 // doHandle processes the message synchronously
 func (h *TriggerHandler) doHandle(ctx context.Context, msg *nats.Msg) {
 	logger := logging.FromContext(ctx)
+
+	// Record the pre-dispatch processing time (message decode + filter eval).
+	// recordProcess is idempotent: it is called explicitly just before dispatch
+	// and via defer, so any early return (unknown encoding, decode failure,
+	// filtered out) is captured exactly once and dispatch time is never
+	// included. It reads the ctx variable at call time, so the span context set
+	// up below is used once available.
+	processStart := time.Now()
+	processRecorded := false
+	recordProcess := func() {
+		if processRecorded || h.processDuration == nil {
+			return
+		}
+		processRecorded = true
+		h.processDuration.Record(ctx, time.Since(processStart).Seconds(),
+			metric.WithAttributes(
+				attribute.String("kn.trigger.name", h.trigger.Name),
+				attribute.String("kn.trigger.namespace", h.trigger.Namespace),
+			))
+	}
+	defer recordProcess()
 
 	// Convert NATS message to CloudEvents message
 	message := cejs.NewMessage(msg)
@@ -195,10 +221,10 @@ func (h *TriggerHandler) doHandle(ctx context.Context, msg *nats.Msg) {
 	ctx, span := h.tracer.Start(ctx, "broker.filter.dispatch")
 	defer span.End()
 	span.SetAttributes(
-		attribute.String("trigger.name", h.trigger.Name),
-		attribute.String("trigger.namespace", h.trigger.Namespace),
-		attribute.String("trigger.uid", string(h.trigger.UID)),
-		attribute.String("subscriber.url", h.subscriber.URL.String()),
+		attribute.String("kn.trigger.name", h.trigger.Name),
+		attribute.String("kn.trigger.namespace", h.trigger.Namespace),
+		attribute.String("kn.trigger.uid", string(h.trigger.UID)),
+		attribute.String("messaging.destination.name", h.subscriber.URL.String()),
 		attribute.String("ce.id", event.ID()),
 		attribute.String("ce.type", event.Type()),
 		attribute.String("ce.source", event.Source()),
@@ -229,6 +255,10 @@ func (h *TriggerHandler) doHandle(ctx context.Context, msg *nats.Msg) {
 		zap.String("source", event.Source()),
 		zap.String("id", event.ID()),
 	)
+
+	// Pre-dispatch work is done; record it before the HTTP call so dispatch
+	// time (tracked separately by dispatchDuration) is excluded.
+	recordProcess()
 
 	dispatchInfo, err := h.dispatchEvent(ctx, event, msg)
 	if dispatchInfo != nil && dispatchInfo.ResponseCode != 0 {
@@ -286,8 +316,8 @@ func (h *TriggerHandler) dispatchEvent(ctx context.Context, event *cloudevents.E
 	if h.dispatchDuration != nil && dispatchInfo != nil && dispatchInfo.Duration >= 0 {
 		h.dispatchDuration.Record(ctx, dispatchInfo.Duration.Seconds(),
 			metric.WithAttributes(
-				attribute.String("trigger.name", h.trigger.Name),
-				attribute.String("trigger.namespace", h.trigger.Namespace),
+				attribute.String("kn.trigger.name", h.trigger.Name),
+				attribute.String("kn.trigger.namespace", h.trigger.Namespace),
 			))
 	}
 

--- a/pkg/broker/filter/handler_message_test.go
+++ b/pkg/broker/filter/handler_message_test.go
@@ -87,7 +87,7 @@ func newTestHandler(t *testing.T, ctx context.Context, subscriberURL string, fil
 	subscriber := duckv1.Addressable{URL: u}
 	trigger := makeTrigger("default", "test-trigger", filterType)
 	dispatcher := newTestDispatcher(ctx)
-	h, err := NewTriggerHandler(ctx, trigger, subscriber, nil, nil, nil, nil, dispatcher, nil, nil)
+	h, err := NewTriggerHandler(ctx, trigger, subscriber, nil, nil, nil, nil, dispatcher, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("NewTriggerHandler: %v", err)
 	}

--- a/pkg/broker/filter/handler_message_test.go
+++ b/pkg/broker/filter/handler_message_test.go
@@ -87,7 +87,7 @@ func newTestHandler(t *testing.T, ctx context.Context, subscriberURL string, fil
 	subscriber := duckv1.Addressable{URL: u}
 	trigger := makeTrigger("default", "test-trigger", filterType)
 	dispatcher := newTestDispatcher(ctx)
-	h, err := NewTriggerHandler(ctx, trigger, subscriber, nil, nil, nil, nil, dispatcher)
+	h, err := NewTriggerHandler(ctx, trigger, subscriber, nil, nil, nil, nil, dispatcher, nil, nil)
 	if err != nil {
 		t.Fatalf("NewTriggerHandler: %v", err)
 	}

--- a/pkg/broker/filter/handler_test.go
+++ b/pkg/broker/filter/handler_test.go
@@ -551,7 +551,7 @@ func TestNewTriggerHandler(t *testing.T) {
 	subscriberURL, _ := apis.ParseURL("http://subscriber.example.com")
 	subscriber := duckv1.Addressable{URL: subscriberURL}
 
-	handler, err := NewTriggerHandler(ctx, trigger, subscriber, nil, nil, nil, nil, nil, nil, nil)
+	handler, err := NewTriggerHandler(ctx, trigger, subscriber, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("NewTriggerHandler() unexpected error: %v", err)
 	}
@@ -603,7 +603,7 @@ func TestNewTriggerHandler_WithOptionalParams(t *testing.T) {
 	retryConfig := &kncloudevents.RetryConfig{RetryMax: 3}
 	noRetryConfig := &kncloudevents.RetryConfig{RetryMax: 0}
 
-	handler, err := NewTriggerHandler(ctx, trigger, subscriber, brokerIngress, dls, retryConfig, noRetryConfig, nil, nil, nil)
+	handler, err := NewTriggerHandler(ctx, trigger, subscriber, brokerIngress, dls, retryConfig, noRetryConfig, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("NewTriggerHandler() unexpected error: %v", err)
 	}

--- a/pkg/broker/filter/handler_test.go
+++ b/pkg/broker/filter/handler_test.go
@@ -551,7 +551,7 @@ func TestNewTriggerHandler(t *testing.T) {
 	subscriberURL, _ := apis.ParseURL("http://subscriber.example.com")
 	subscriber := duckv1.Addressable{URL: subscriberURL}
 
-	handler, err := NewTriggerHandler(ctx, trigger, subscriber, nil, nil, nil, nil, nil)
+	handler, err := NewTriggerHandler(ctx, trigger, subscriber, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("NewTriggerHandler() unexpected error: %v", err)
 	}
@@ -603,7 +603,7 @@ func TestNewTriggerHandler_WithOptionalParams(t *testing.T) {
 	retryConfig := &kncloudevents.RetryConfig{RetryMax: 3}
 	noRetryConfig := &kncloudevents.RetryConfig{RetryMax: 0}
 
-	handler, err := NewTriggerHandler(ctx, trigger, subscriber, brokerIngress, dls, retryConfig, noRetryConfig, nil)
+	handler, err := NewTriggerHandler(ctx, trigger, subscriber, brokerIngress, dls, retryConfig, noRetryConfig, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("NewTriggerHandler() unexpected error: %v", err)
 	}


### PR DESCRIPTION
Add distributed-tracing and OpenTelemetry metrics to the NATS JetStream broker filter, matching the channel implementation's instrumentation. Previously the filter was a black hole in traces (trace IDs propagated end-to-end via CloudEvent extensions, but no filter-side span existed) and emitted no application-level metrics.

The tracer/meter are resolved from the global OTel providers — whatever sharedmain registers is what gets used. Zero-config: stays no-op until a real exporter is wired upstream.

