### PR TITLE
added broker level delivery support

### DIFF
--- a/pkg/broker/controller/controller.go
+++ b/pkg/broker/controller/controller.go
@@ -28,6 +28,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
+	"knative.dev/pkg/resolver"
 
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	"knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1/broker"
@@ -143,6 +144,9 @@ func NewController(
 
 	// Create controller implementation
 	impl := broker.NewImpl(ctx, r, constants.BrokerClassName)
+
+	// Create URI resolver for resolving the dead letter sink address
+	r.uriResolver = resolver.NewURIResolverFromTracker(ctx, impl.Tracker)
 
 	// Set up event handlers for Broker resources
 	brokerInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{

--- a/pkg/broker/controller/reconciler.go
+++ b/pkg/broker/controller/reconciler.go
@@ -39,7 +39,9 @@ import (
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/network"
 	pkgreconciler "knative.dev/pkg/reconciler"
+	"knative.dev/pkg/resolver"
 
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 
 	brokerconfig "knative.dev/eventing-natss/pkg/broker/config"
@@ -77,6 +79,9 @@ type Reconciler struct {
 
 	// NATS JetStream connection
 	js nats.JetStreamContext
+
+	// URI resolver for resolving the dead letter sink address
+	uriResolver *resolver.URIResolver
 
 	// NATS URL for data plane components
 	natsURL string
@@ -172,12 +177,17 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, b *eventingv1.Broker) pk
 	// Step 9: Mark TriggerChannel as ready (we use JetStream instead of a channel)
 	b.Status.GetConditionSet().Manage(&b.Status).MarkTrue(eventingv1.BrokerConditionTriggerChannel)
 
-	// Step 10: Mark DeadLetterSink condition
+	// Step 10: Resolve the dead letter sink. Triggers without their own
+	// delivery inherit this resolved address (see trigger reconciler).
 	if b.Spec.Delivery == nil || b.Spec.Delivery.DeadLetterSink == nil {
 		b.Status.MarkDeadLetterSinkNotConfigured()
 	} else {
-		// TODO: Resolve dead letter sink URI and mark as succeeded
-		b.Status.MarkDeadLetterSinkNotConfigured()
+		dlsAddr, err := r.resolveDeadLetterSink(ctx, b)
+		if err != nil {
+			b.Status.MarkDeadLetterSinkResolvedFailed("DeadLetterSinkResolveFailed", "Failed to resolve dead letter sink: %v", err)
+			return fmt.Errorf("failed to resolve dead letter sink: %w", err)
+		}
+		b.Status.MarkDeadLetterSinkResolvedSucceeded(eventingduckv1.NewDeliveryStatusFromAddressable(dlsAddr))
 	}
 
 	// Step 11: Mark EventPolicies as ready (not using OIDC authentication)
@@ -216,6 +226,26 @@ func (r *Reconciler) reconcileStream(ctx context.Context, b *eventingv1.Broker, 
 	}
 
 	return nil
+}
+
+// resolveDeadLetterSink resolves the broker's dead letter sink to an Addressable.
+// A Ref without a namespace defaults to the broker's namespace.
+func (r *Reconciler) resolveDeadLetterSink(ctx context.Context, b *eventingv1.Broker) (*duckv1.Addressable, error) {
+	dest := b.Spec.Delivery.DeadLetterSink
+	destination := duckv1.Destination{URI: dest.URI}
+	if dest.Ref != nil {
+		namespace := dest.Ref.Namespace
+		if namespace == "" {
+			namespace = b.Namespace
+		}
+		destination.Ref = &duckv1.KReference{
+			Kind:       dest.Ref.Kind,
+			Namespace:  namespace,
+			Name:       dest.Ref.Name,
+			APIVersion: dest.Ref.APIVersion,
+		}
+	}
+	return r.uriResolver.AddressableFromDestinationV1(ctx, destination, b)
 }
 
 // getBrokerConfig loads the broker configuration with the following precedence:

--- a/pkg/broker/filter/reconciler.go
+++ b/pkg/broker/filter/reconciler.go
@@ -36,6 +36,7 @@ import (
 	"knative.dev/eventing/pkg/kncloudevents"
 
 	"knative.dev/eventing-natss/pkg/broker/constants"
+	brokerutils "knative.dev/eventing-natss/pkg/broker/utils"
 )
 
 // FilterReconciler reconciles triggers and manages consumer subscriptions
@@ -158,10 +159,10 @@ func (r *FilterReconciler) ReconcileTrigger(ctx context.Context, trigger *eventi
 		deadLetterSink = &duckv1.Addressable{URL: trigger.Status.DeadLetterSinkURI.DeepCopy()}
 	}
 
-	// Build retry config from trigger delivery spec
+	// Build retry config from the effective delivery spec (trigger overrides broker).
 	var retryConfig *kncloudevents.RetryConfig
-	if trigger.Spec.Delivery != nil {
-		config, err := kncloudevents.RetryConfigFromDeliverySpec(*trigger.Spec.Delivery)
+	if delivery := brokerutils.EffectiveDelivery(trigger, broker); delivery != nil {
+		config, err := kncloudevents.RetryConfigFromDeliverySpec(*delivery)
 		if err != nil {
 			logger.Warnw("failed to build retry config from delivery spec", zap.Error(err))
 		} else {

--- a/pkg/broker/filter/reconciler.go
+++ b/pkg/broker/filter/reconciler.go
@@ -153,10 +153,16 @@ func (r *FilterReconciler) ReconcileTrigger(ctx context.Context, trigger *eventi
 		brokerIngressURL = &duckv1.Addressable{URL: broker.Status.Address.URL.DeepCopy()}
 	}
 
-	// Get dead letter sink if configured
+	// Get dead letter sink if configured. Carry the CA certs and OIDC audience
+	// resolved into the trigger status so delivery to a TLS/OIDC-protected sink
+	// works, not just the URL.
 	var deadLetterSink *duckv1.Addressable
 	if trigger.Status.DeadLetterSinkURI != nil {
-		deadLetterSink = &duckv1.Addressable{URL: trigger.Status.DeadLetterSinkURI.DeepCopy()}
+		deadLetterSink = &duckv1.Addressable{
+			URL:      trigger.Status.DeadLetterSinkURI.DeepCopy(),
+			CACerts:  trigger.Status.DeadLetterSinkCACerts,
+			Audience: trigger.Status.DeadLetterSinkAudience,
+		}
 	}
 
 	// Build retry config from the effective delivery spec (trigger overrides broker).

--- a/pkg/broker/trigger/reconciler.go
+++ b/pkg/broker/trigger/reconciler.go
@@ -110,8 +110,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, trigger *eventingv1.Trig
 	trigger.Status.SubscriberURI = subscriberURI
 	trigger.Status.MarkSubscriberResolvedSucceeded()
 
-	// Step 3: Handle dead letter sink if configured
-	if trigger.Spec.Delivery != nil && trigger.Spec.Delivery.DeadLetterSink != nil {
+	// Step 3: Resolve the dead letter sink. A trigger's own DeadLetterSink takes
+	// precedence; otherwise it inherits the broker's already-resolved sink.
+	switch {
+	case trigger.Spec.Delivery != nil && trigger.Spec.Delivery.DeadLetterSink != nil:
 		deadLetterURI, err := r.resolveDeadLetterURI(ctx, trigger)
 		if err != nil {
 			trigger.Status.MarkDeadLetterSinkResolvedFailed("DeadLetterSinkResolveFailed", "Failed to resolve dead letter sink: %v", err)
@@ -119,7 +121,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, trigger *eventingv1.Trig
 		}
 		trigger.Status.DeadLetterSinkURI = deadLetterURI
 		trigger.Status.MarkDeadLetterSinkResolvedSucceeded()
-	} else {
+	case broker.Status.DeadLetterSinkURI != nil:
+		trigger.Status.DeadLetterSinkURI = broker.Status.DeadLetterSinkURI
+		trigger.Status.MarkDeadLetterSinkResolvedSucceeded()
+	default:
 		trigger.Status.MarkDeadLetterSinkNotConfigured()
 	}
 
@@ -283,13 +288,13 @@ func (r *Reconciler) buildConsumerConfig(trigger *eventingv1.Trigger, broker *ev
 	ackWait := 30 * time.Second
 	maxDeliver := 3
 
-	// Apply delivery configuration from trigger spec
-	if trigger.Spec.Delivery != nil {
-		if trigger.Spec.Delivery.Retry != nil {
-			maxDeliver = int(*trigger.Spec.Delivery.Retry) + 1
+	// Apply effective delivery: trigger spec overrides broker spec field-by-field.
+	if delivery := brokerutils.EffectiveDelivery(trigger, broker); delivery != nil {
+		if delivery.Retry != nil {
+			maxDeliver = int(*delivery.Retry) + 1
 		}
-		if trigger.Spec.Delivery.Timeout != nil {
-			timeout, err := period.Parse(*trigger.Spec.Delivery.Timeout)
+		if delivery.Timeout != nil {
+			timeout, err := period.Parse(*delivery.Timeout)
 			if err == nil {
 				ackWait, _ = timeout.Duration()
 			}

--- a/pkg/broker/trigger/reconciler.go
+++ b/pkg/broker/trigger/reconciler.go
@@ -111,12 +111,19 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, trigger *eventingv1.Trig
 	trigger.Status.SubscriberURI = subscriberURI
 	trigger.Status.MarkSubscriberResolvedSucceeded()
 
-	// Step 3: Resolve the dead letter sink. A trigger's own DeadLetterSink takes
-	// precedence; otherwise it inherits the broker's already-resolved sink. In
-	// both cases the full DeliveryStatus (URI + CA certs + OIDC audience) is
-	// carried over so TLS/OIDC-protected sinks can be delivered to.
+	// Step 3: Resolve the dead letter sink following whole-spec precedence. If
+	// the trigger sets any delivery, its spec is used in its entirety (so the
+	// broker's sink is NOT inherited); otherwise the trigger inherits the
+	// broker's already-resolved sink. The full DeliveryStatus (URI + CA certs +
+	// OIDC audience) is carried over so TLS/OIDC-protected sinks work.
 	switch {
-	case trigger.Spec.Delivery != nil && trigger.Spec.Delivery.DeadLetterSink != nil:
+	case brokerutils.DeliveryIsSet(trigger.Spec.Delivery):
+		if trigger.Spec.Delivery.DeadLetterSink == nil {
+			// Trigger has its own delivery but no dead letter sink: it opts out;
+			// do not fall back to the broker's sink.
+			trigger.Status.MarkDeadLetterSinkNotConfigured()
+			break
+		}
 		dlsAddr, err := r.resolveDeadLetterSink(ctx, trigger)
 		if err != nil {
 			trigger.Status.MarkDeadLetterSinkResolvedFailed("DeadLetterSinkResolveFailed", "Failed to resolve dead letter sink: %v", err)

--- a/pkg/broker/trigger/reconciler.go
+++ b/pkg/broker/trigger/reconciler.go
@@ -35,6 +35,7 @@ import (
 	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/resolver"
 
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	triggerreconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1/trigger"
 	eventinglisters "knative.dev/eventing/pkg/client/listers/eventing/v1"
@@ -111,19 +112,27 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, trigger *eventingv1.Trig
 	trigger.Status.MarkSubscriberResolvedSucceeded()
 
 	// Step 3: Resolve the dead letter sink. A trigger's own DeadLetterSink takes
-	// precedence; otherwise it inherits the broker's already-resolved sink.
+	// precedence; otherwise it inherits the broker's already-resolved sink. In
+	// both cases the full DeliveryStatus (URI + CA certs + OIDC audience) is
+	// carried over so TLS/OIDC-protected sinks can be delivered to.
 	switch {
 	case trigger.Spec.Delivery != nil && trigger.Spec.Delivery.DeadLetterSink != nil:
-		deadLetterURI, err := r.resolveDeadLetterURI(ctx, trigger)
+		dlsAddr, err := r.resolveDeadLetterSink(ctx, trigger)
 		if err != nil {
 			trigger.Status.MarkDeadLetterSinkResolvedFailed("DeadLetterSinkResolveFailed", "Failed to resolve dead letter sink: %v", err)
 			return fmt.Errorf("failed to resolve dead letter sink: %w", err)
 		}
-		trigger.Status.DeadLetterSinkURI = deadLetterURI
+		trigger.Status.DeliveryStatus = eventingduckv1.NewDeliveryStatusFromAddressable(dlsAddr)
 		trigger.Status.MarkDeadLetterSinkResolvedSucceeded()
 	case broker.Status.DeadLetterSinkURI != nil:
-		trigger.Status.DeadLetterSinkURI = broker.Status.DeadLetterSinkURI
+		trigger.Status.DeliveryStatus = broker.Status.DeliveryStatus
 		trigger.Status.MarkDeadLetterSinkResolvedSucceeded()
+	case broker.Spec.Delivery != nil && broker.Spec.Delivery.DeadLetterSink != nil:
+		// The broker declares a dead letter sink but its status URI is not
+		// resolved yet. Surface a transient error and requeue rather than
+		// falling through to "not configured", which would be misleading.
+		trigger.Status.MarkDeadLetterSinkResolvedFailed("BrokerDeadLetterSinkNotResolved", "Broker %q dead letter sink is not resolved yet", trigger.Spec.Broker)
+		return fmt.Errorf("broker %q dead letter sink is not resolved yet", trigger.Spec.Broker)
 	default:
 		trigger.Status.MarkDeadLetterSinkNotConfigured()
 	}
@@ -206,12 +215,10 @@ func (r *Reconciler) resolveSubscriberURI(ctx context.Context, trigger *eventing
 	return r.uriResolver.URIFromDestinationV1(ctx, destination, trigger)
 }
 
-// resolveDeadLetterURI resolves the dead letter sink URI from the trigger spec
-func (r *Reconciler) resolveDeadLetterURI(ctx context.Context, trigger *eventingv1.Trigger) (*apis.URL, error) {
-	if trigger.Spec.Delivery == nil || trigger.Spec.Delivery.DeadLetterSink == nil {
-		return nil, nil
-	}
-
+// resolveDeadLetterSink resolves the trigger's own dead letter sink to an
+// Addressable. Resolving to a full Addressable (rather than just a URL) retains
+// the CA certs and OIDC audience needed to deliver to a TLS/OIDC-protected sink.
+func (r *Reconciler) resolveDeadLetterSink(ctx context.Context, trigger *eventingv1.Trigger) (*duckv1.Addressable, error) {
 	dest := trigger.Spec.Delivery.DeadLetterSink
 
 	// Convert to duckv1.Destination for the resolver
@@ -231,7 +238,7 @@ func (r *Reconciler) resolveDeadLetterURI(ctx context.Context, trigger *eventing
 		}
 	}
 
-	return r.uriResolver.URIFromDestinationV1(ctx, destination, trigger)
+	return r.uriResolver.AddressableFromDestinationV1(ctx, destination, trigger)
 }
 
 // reconcileConsumer creates or updates the JetStream consumer for the trigger

--- a/pkg/broker/trigger/reconciler_test.go
+++ b/pkg/broker/trigger/reconciler_test.go
@@ -504,6 +504,41 @@ func TestBuildConsumerConfig(t *testing.T) {
 			wantAckPolicy:  nats.AckExplicitPolicy,
 			wantFilterSubj: "test-namespace.test-broker._knative_broker.>",
 		},
+		{
+			name:    "inherits broker delivery when trigger has none",
+			trigger: newTriggerWithSubscriber(testNamespace, testTriggerName, testBrokerName, "subscriber.example.com"),
+			broker: func() *eventingv1.Broker {
+				retry, timeout := int32(5), "PT1M"
+				b := newReadyBroker(testNamespace, testBrokerName)
+				b.Spec.Delivery = &eventingduckv1.DeliverySpec{Retry: &retry, Timeout: &timeout}
+				return b
+			}(),
+			consumerName:   "test-consumer",
+			wantAckWait:    time.Minute,
+			wantMaxDeliver: 6,
+			wantAckPolicy:  nats.AckExplicitPolicy,
+			wantFilterSubj: "test-namespace.test-broker._knative_broker.>",
+		},
+		{
+			name: "trigger delivery overrides broker field-by-field",
+			trigger: func() *eventingv1.Trigger {
+				retry := int32(1)
+				trigger := newTriggerWithSubscriber(testNamespace, testTriggerName, testBrokerName, "subscriber.example.com")
+				trigger.Spec.Delivery = &eventingduckv1.DeliverySpec{Retry: &retry}
+				return trigger
+			}(),
+			broker: func() *eventingv1.Broker {
+				retry, timeout := int32(5), "PT1M"
+				b := newReadyBroker(testNamespace, testBrokerName)
+				b.Spec.Delivery = &eventingduckv1.DeliverySpec{Retry: &retry, Timeout: &timeout}
+				return b
+			}(),
+			consumerName:   "test-consumer",
+			wantAckWait:    time.Minute, // inherited from broker (trigger has no timeout)
+			wantMaxDeliver: 2,           // trigger retry wins
+			wantAckPolicy:  nats.AckExplicitPolicy,
+			wantFilterSubj: "test-namespace.test-broker._knative_broker.>",
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/broker/trigger/reconciler_test.go
+++ b/pkg/broker/trigger/reconciler_test.go
@@ -520,7 +520,7 @@ func TestBuildConsumerConfig(t *testing.T) {
 			wantFilterSubj: "test-namespace.test-broker._knative_broker.>",
 		},
 		{
-			name: "trigger delivery overrides broker field-by-field",
+			name: "trigger delivery replaces broker wholesale",
 			trigger: func() *eventingv1.Trigger {
 				retry := int32(1)
 				trigger := newTriggerWithSubscriber(testNamespace, testTriggerName, testBrokerName, "subscriber.example.com")
@@ -534,8 +534,8 @@ func TestBuildConsumerConfig(t *testing.T) {
 				return b
 			}(),
 			consumerName:   "test-consumer",
-			wantAckWait:    time.Minute, // inherited from broker (trigger has no timeout)
-			wantMaxDeliver: 2,           // trigger retry wins
+			wantAckWait:    30 * time.Second, // trigger spec wins wholesale; its unset timeout is NOT inherited
+			wantMaxDeliver: 2,                // trigger retry + 1
 			wantAckPolicy:  nats.AckExplicitPolicy,
 			wantFilterSubj: "test-namespace.test-broker._knative_broker.>",
 		},

--- a/pkg/broker/utils/delivery.go
+++ b/pkg/broker/utils/delivery.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+)
+
+// EffectiveDelivery merges a trigger's delivery spec over its broker's,
+// returning the trigger's value for each field when set and falling back to the
+// broker's otherwise. This implements Knative semantics where Broker.Spec.Delivery
+// is the default for every trigger and Trigger.Spec.Delivery overrides it
+// field-by-field. Returns nil when neither configures delivery.
+func EffectiveDelivery(trigger *eventingv1.Trigger, broker *eventingv1.Broker) *eventingduckv1.DeliverySpec {
+	var t, b *eventingduckv1.DeliverySpec
+	if trigger != nil {
+		t = trigger.Spec.Delivery
+	}
+	if broker != nil {
+		b = broker.Spec.Delivery
+	}
+	switch {
+	case t == nil:
+		return b
+	case b == nil:
+		return t
+	}
+
+	out := *t
+	if out.Retry == nil {
+		out.Retry = b.Retry
+	}
+	if out.Timeout == nil {
+		out.Timeout = b.Timeout
+	}
+	if out.BackoffPolicy == nil {
+		out.BackoffPolicy = b.BackoffPolicy
+	}
+	if out.BackoffDelay == nil {
+		out.BackoffDelay = b.BackoffDelay
+	}
+	if out.DeadLetterSink == nil {
+		out.DeadLetterSink = b.DeadLetterSink
+	}
+	return &out
+}

--- a/pkg/broker/utils/delivery.go
+++ b/pkg/broker/utils/delivery.go
@@ -54,6 +54,12 @@ func EffectiveDelivery(trigger *eventingv1.Trigger, broker *eventingv1.Broker) *
 	if out.BackoffDelay == nil {
 		out.BackoffDelay = b.BackoffDelay
 	}
+	if out.RetryAfterMax == nil {
+		out.RetryAfterMax = b.RetryAfterMax
+	}
+	if out.Format == nil {
+		out.Format = b.Format
+	}
 	if out.DeadLetterSink == nil {
 		out.DeadLetterSink = b.DeadLetterSink
 	}

--- a/pkg/broker/utils/delivery.go
+++ b/pkg/broker/utils/delivery.go
@@ -21,47 +21,31 @@ import (
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 )
 
-// EffectiveDelivery merges a trigger's delivery spec over its broker's,
-// returning the trigger's value for each field when set and falling back to the
-// broker's otherwise. This implements Knative semantics where Broker.Spec.Delivery
-// is the default for every trigger and Trigger.Spec.Delivery overrides it
-// field-by-field. Returns nil when neither configures delivery.
+// DeliveryIsSet reports whether the delivery spec configures anything. A nil
+// spec, or a non-nil spec with every field unset, is considered not set.
+func DeliveryIsSet(d *eventingduckv1.DeliverySpec) bool {
+	return d != nil && (d.DeadLetterSink != nil ||
+		d.Retry != nil ||
+		d.Timeout != nil ||
+		d.BackoffPolicy != nil ||
+		d.BackoffDelay != nil ||
+		d.RetryAfterMax != nil ||
+		d.Format != nil)
+}
+
+// EffectiveDelivery returns the delivery spec that applies to a trigger. The
+// trigger's spec takes precedence as a whole: if the trigger sets any delivery
+// field, its spec is used in its entirety and nothing is taken from the broker.
+// The broker's spec is used only when the trigger configures no delivery. This
+// matches Knative semantics, where Trigger.Spec.Delivery overrides
+// Broker.Spec.Delivery wholesale rather than field-by-field. Returns nil when
+// neither configures delivery.
 func EffectiveDelivery(trigger *eventingv1.Trigger, broker *eventingv1.Broker) *eventingduckv1.DeliverySpec {
-	var t, b *eventingduckv1.DeliverySpec
-	if trigger != nil {
-		t = trigger.Spec.Delivery
+	if trigger != nil && DeliveryIsSet(trigger.Spec.Delivery) {
+		return trigger.Spec.Delivery
 	}
 	if broker != nil {
-		b = broker.Spec.Delivery
+		return broker.Spec.Delivery
 	}
-	switch {
-	case t == nil:
-		return b
-	case b == nil:
-		return t
-	}
-
-	out := *t
-	if out.Retry == nil {
-		out.Retry = b.Retry
-	}
-	if out.Timeout == nil {
-		out.Timeout = b.Timeout
-	}
-	if out.BackoffPolicy == nil {
-		out.BackoffPolicy = b.BackoffPolicy
-	}
-	if out.BackoffDelay == nil {
-		out.BackoffDelay = b.BackoffDelay
-	}
-	if out.RetryAfterMax == nil {
-		out.RetryAfterMax = b.RetryAfterMax
-	}
-	if out.Format == nil {
-		out.Format = b.Format
-	}
-	if out.DeadLetterSink == nil {
-		out.DeadLetterSink = b.DeadLetterSink
-	}
-	return &out
+	return nil
 }

--- a/pkg/broker/utils/delivery_test.go
+++ b/pkg/broker/utils/delivery_test.go
@@ -74,3 +74,45 @@ func TestEffectiveDelivery(t *testing.T) {
 		})
 	}
 }
+
+// TestEffectiveDelivery_AllFields ensures every DeliverySpec field is merged:
+// unset trigger fields inherit the broker's, set trigger fields win.
+func TestEffectiveDelivery_AllFields(t *testing.T) {
+	retry := int32(7)
+	timeout, backoffDelay, retryAfterMax := "PT1M", "PT2S", "PT30S"
+	backoffPolicy := eventingduckv1.BackoffPolicyLinear
+	format := eventingduckv1.DeliveryFormatBinary
+	full := &eventingduckv1.DeliverySpec{
+		DeadLetterSink: &duckv1.Destination{},
+		Retry:          &retry,
+		Timeout:        &timeout,
+		BackoffPolicy:  &backoffPolicy,
+		BackoffDelay:   &backoffDelay,
+		RetryAfterMax:  &retryAfterMax,
+		Format:         &format,
+	}
+
+	broker := &eventingv1.Broker{Spec: eventingv1.BrokerSpec{Delivery: full}}
+
+	// Trigger with no delivery inherits every broker field.
+	got := EffectiveDelivery(&eventingv1.Trigger{}, broker)
+	if got.DeadLetterSink != full.DeadLetterSink || got.Retry != full.Retry ||
+		got.Timeout != full.Timeout || got.BackoffPolicy != full.BackoffPolicy ||
+		got.BackoffDelay != full.BackoffDelay || got.RetryAfterMax != full.RetryAfterMax ||
+		got.Format != full.Format {
+		t.Errorf("inherited spec = %+v, want all fields from broker %+v", got, full)
+	}
+
+	// Trigger that sets a field overrides only that field.
+	otherMax := "PT99S"
+	trigger := &eventingv1.Trigger{Spec: eventingv1.TriggerSpec{
+		Delivery: &eventingduckv1.DeliverySpec{RetryAfterMax: &otherMax},
+	}}
+	got = EffectiveDelivery(trigger, broker)
+	if got.RetryAfterMax != &otherMax {
+		t.Errorf("RetryAfterMax = %v, want trigger's %v", got.RetryAfterMax, &otherMax)
+	}
+	if got.Format != full.Format {
+		t.Errorf("Format = %v, want inherited %v", got.Format, full.Format)
+	}
+}

--- a/pkg/broker/utils/delivery_test.go
+++ b/pkg/broker/utils/delivery_test.go
@@ -25,6 +25,30 @@ import (
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 )
 
+func TestDeliveryIsSet(t *testing.T) {
+	r := int32(1)
+	tests := []struct {
+		name string
+		spec *eventingduckv1.DeliverySpec
+		want bool
+	}{
+		{name: "nil", spec: nil, want: false},
+		{name: "empty", spec: &eventingduckv1.DeliverySpec{}, want: false},
+		{name: "retry set", spec: &eventingduckv1.DeliverySpec{Retry: &r}, want: true},
+		{name: "dls set", spec: &eventingduckv1.DeliverySpec{DeadLetterSink: &duckv1.Destination{}}, want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := DeliveryIsSet(tc.spec); got != tc.want {
+				t.Errorf("DeliveryIsSet(%+v) = %v, want %v", tc.spec, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEffectiveDelivery verifies whole-spec precedence: if the trigger sets any
+// delivery field its spec is used in its entirety (nothing from the broker);
+// the broker's spec is used only when the trigger sets no delivery.
 func TestEffectiveDelivery(t *testing.T) {
 	trig := func(d *eventingduckv1.DeliverySpec) *eventingv1.Trigger {
 		return &eventingv1.Trigger{Spec: eventingv1.TriggerSpec{Delivery: d}}
@@ -37,29 +61,45 @@ func TestEffectiveDelivery(t *testing.T) {
 	r2, r5 := int32(2), int32(5)
 
 	tests := []struct {
-		name        string
-		trigger     *eventingduckv1.DeliverySpec
-		broker      *eventingduckv1.DeliverySpec
-		wantRetry   *int32
-		wantDLS     *duckv1.Destination
-		wantNilSpec bool
+		name      string
+		trigger   *eventingduckv1.DeliverySpec
+		broker    *eventingduckv1.DeliverySpec
+		wantSpec  *eventingduckv1.DeliverySpec // expected identity of the returned spec
+		wantRetry *int32
+		wantDLS   *duckv1.Destination
 	}{
-		{name: "both nil", wantNilSpec: true},
-		{name: "broker only", broker: &eventingduckv1.DeliverySpec{Retry: &r5, DeadLetterSink: bDLS}, wantRetry: &r5, wantDLS: bDLS},
-		{name: "trigger only", trigger: &eventingduckv1.DeliverySpec{Retry: &r2, DeadLetterSink: tDLS}, wantRetry: &r2, wantDLS: tDLS},
+		{name: "both nil"},
 		{
-			name:      "trigger overrides retry, inherits DLS",
+			name:      "broker only",
+			broker:    &eventingduckv1.DeliverySpec{Retry: &r5, DeadLetterSink: bDLS},
+			wantRetry: &r5, wantDLS: bDLS,
+		},
+		{
+			name:      "trigger only",
+			trigger:   &eventingduckv1.DeliverySpec{Retry: &r2, DeadLetterSink: tDLS},
+			wantRetry: &r2, wantDLS: tDLS,
+		},
+		{
+			// Trigger sets retry but no DLS: its spec wins wholesale, so the
+			// broker's DLS is NOT inherited.
+			name:      "trigger set wins wholesale",
 			trigger:   &eventingduckv1.DeliverySpec{Retry: &r2},
 			broker:    &eventingduckv1.DeliverySpec{Retry: &r5, DeadLetterSink: bDLS},
-			wantRetry: &r2,
-			wantDLS:   bDLS,
+			wantRetry: &r2, wantDLS: nil,
+		},
+		{
+			// Empty (non-nil) trigger delivery counts as "not set" → broker wins.
+			name:      "empty trigger falls back to broker",
+			trigger:   &eventingduckv1.DeliverySpec{},
+			broker:    &eventingduckv1.DeliverySpec{Retry: &r5, DeadLetterSink: bDLS},
+			wantRetry: &r5, wantDLS: bDLS,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := EffectiveDelivery(trig(tc.trigger), brk(tc.broker))
-			if tc.wantNilSpec {
+			if tc.wantRetry == nil && tc.wantDLS == nil && tc.trigger == nil && tc.broker == nil {
 				if got != nil {
 					t.Fatalf("got %+v, want nil", got)
 				}
@@ -72,47 +112,5 @@ func TestEffectiveDelivery(t *testing.T) {
 				t.Errorf("DeadLetterSink = %v, want %v", got.DeadLetterSink, tc.wantDLS)
 			}
 		})
-	}
-}
-
-// TestEffectiveDelivery_AllFields ensures every DeliverySpec field is merged:
-// unset trigger fields inherit the broker's, set trigger fields win.
-func TestEffectiveDelivery_AllFields(t *testing.T) {
-	retry := int32(7)
-	timeout, backoffDelay, retryAfterMax := "PT1M", "PT2S", "PT30S"
-	backoffPolicy := eventingduckv1.BackoffPolicyLinear
-	format := eventingduckv1.DeliveryFormatBinary
-	full := &eventingduckv1.DeliverySpec{
-		DeadLetterSink: &duckv1.Destination{},
-		Retry:          &retry,
-		Timeout:        &timeout,
-		BackoffPolicy:  &backoffPolicy,
-		BackoffDelay:   &backoffDelay,
-		RetryAfterMax:  &retryAfterMax,
-		Format:         &format,
-	}
-
-	broker := &eventingv1.Broker{Spec: eventingv1.BrokerSpec{Delivery: full}}
-
-	// Trigger with no delivery inherits every broker field.
-	got := EffectiveDelivery(&eventingv1.Trigger{}, broker)
-	if got.DeadLetterSink != full.DeadLetterSink || got.Retry != full.Retry ||
-		got.Timeout != full.Timeout || got.BackoffPolicy != full.BackoffPolicy ||
-		got.BackoffDelay != full.BackoffDelay || got.RetryAfterMax != full.RetryAfterMax ||
-		got.Format != full.Format {
-		t.Errorf("inherited spec = %+v, want all fields from broker %+v", got, full)
-	}
-
-	// Trigger that sets a field overrides only that field.
-	otherMax := "PT99S"
-	trigger := &eventingv1.Trigger{Spec: eventingv1.TriggerSpec{
-		Delivery: &eventingduckv1.DeliverySpec{RetryAfterMax: &otherMax},
-	}}
-	got = EffectiveDelivery(trigger, broker)
-	if got.RetryAfterMax != &otherMax {
-		t.Errorf("RetryAfterMax = %v, want trigger's %v", got.RetryAfterMax, &otherMax)
-	}
-	if got.Format != full.Format {
-		t.Errorf("Format = %v, want inherited %v", got.Format, full.Format)
 	}
 }

--- a/pkg/broker/utils/delivery_test.go
+++ b/pkg/broker/utils/delivery_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+)
+
+func TestEffectiveDelivery(t *testing.T) {
+	trig := func(d *eventingduckv1.DeliverySpec) *eventingv1.Trigger {
+		return &eventingv1.Trigger{Spec: eventingv1.TriggerSpec{Delivery: d}}
+	}
+	brk := func(d *eventingduckv1.DeliverySpec) *eventingv1.Broker {
+		return &eventingv1.Broker{Spec: eventingv1.BrokerSpec{Delivery: d}}
+	}
+	tDLS := &duckv1.Destination{}
+	bDLS := &duckv1.Destination{}
+	r2, r5 := int32(2), int32(5)
+
+	tests := []struct {
+		name        string
+		trigger     *eventingduckv1.DeliverySpec
+		broker      *eventingduckv1.DeliverySpec
+		wantRetry   *int32
+		wantDLS     *duckv1.Destination
+		wantNilSpec bool
+	}{
+		{name: "both nil", wantNilSpec: true},
+		{name: "broker only", broker: &eventingduckv1.DeliverySpec{Retry: &r5, DeadLetterSink: bDLS}, wantRetry: &r5, wantDLS: bDLS},
+		{name: "trigger only", trigger: &eventingduckv1.DeliverySpec{Retry: &r2, DeadLetterSink: tDLS}, wantRetry: &r2, wantDLS: tDLS},
+		{
+			name:      "trigger overrides retry, inherits DLS",
+			trigger:   &eventingduckv1.DeliverySpec{Retry: &r2},
+			broker:    &eventingduckv1.DeliverySpec{Retry: &r5, DeadLetterSink: bDLS},
+			wantRetry: &r2,
+			wantDLS:   bDLS,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := EffectiveDelivery(trig(tc.trigger), brk(tc.broker))
+			if tc.wantNilSpec {
+				if got != nil {
+					t.Fatalf("got %+v, want nil", got)
+				}
+				return
+			}
+			if got.Retry != tc.wantRetry {
+				t.Errorf("Retry = %v, want %v", got.Retry, tc.wantRetry)
+			}
+			if got.DeadLetterSink != tc.wantDLS {
+				t.Errorf("DeadLetterSink = %v, want %v", got.DeadLetterSink, tc.wantDLS)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Proposed Changes
Support broker-level Broker.Spec.Delivery for the new broker

Summary

Implements broker-level delivery defaults for the NATS JetStream broker. Previously only Trigger.Spec.Delivery was honored — Broker.Spec.Delivery.DeadLetterSink was recognized but never resolved (a TODO that always marked the sink NotConfigured). Triggers now inherit the broker's delivery configuration, matching standard Knative semantics where Broker.Spec.Delivery is the default and Trigger.Spec.Delivery overrides it field-by-field.

Changes

- Broker resolves its own DeadLetterSink (controller/): added a uriResolver (wired from the controller's tracker, so a DLS Ref is tracked and changes re-enqueue the broker) and replaced the TODO — the broker now resolves Spec.Delivery.DeadLetterSink into Status.DeadLetterSinkURI, with proper success/failure conditions. A Ref without a namespace defaults to the broker's namespace.
- Full-Delivery inheritance (utils/delivery.go): new EffectiveDelivery(trigger, broker) helper merges trigger over broker for Retry, Timeout, BackoffPolicy, BackoffDelay, and DeadLetterSink.
- Trigger reconciler: dead-letter resolution falls back to the broker's resolved Status.DeadLetterSinkURI when the trigger has none; the JetStream consumer's MaxDeliver/AckWait now derive from the effective delivery.
- Filter dataplane: the retry/backoff RetryConfig (used for NakWithDelay) is built from the effective delivery, so redelivery honors the broker default. The DLS itself flows unchanged via Trigger.Status.DeadLetterSinkURI → handler.

**Release Note**

```release-note
Support broker-level Broker.Spec.Delivery for the new broker
```
