### PR TITLE
Preserve CloudEvent trace context

### DIFF
--- a/pkg/broker/ingress/handler_test.go
+++ b/pkg/broker/ingress/handler_test.go
@@ -31,6 +31,11 @@ import (
 	"knative.dev/eventing-natss/pkg/broker/contract"
 )
 
+const (
+	testTraceParent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	testTraceState  = "vendor=value"
+)
+
 func runBasicJetStreamServer(t *testing.T) *natsserver.Server {
 	t.Helper()
 	opts := natstest.DefaultTestOptions
@@ -38,6 +43,29 @@ func runBasicJetStreamServer(t *testing.T) *natsserver.Server {
 	opts.JetStream = true
 	opts.StoreDir = t.TempDir() // Use temp dir to isolate test state
 	return natstest.RunServer(&opts)
+}
+
+func assertStoredEventTraceContext(t *testing.T, js nats.JetStreamContext, streamName, eventID string) {
+	t.Helper()
+
+	storedMessage, err := js.GetMsg(streamName, 1)
+	if err != nil {
+		t.Fatalf("Failed to get stored message: %v", err)
+	}
+	if got := storedMessage.Header.Get(nats.MsgIdHdr); got != eventID {
+		t.Errorf("Nats-Msg-Id = %q, want %q", got, eventID)
+	}
+
+	var storedEvent map[string]interface{}
+	if err := json.Unmarshal(storedMessage.Data, &storedEvent); err != nil {
+		t.Fatalf("Failed to decode stored CloudEvent: %v", err)
+	}
+	if got := storedEvent["traceparent"]; got != testTraceParent {
+		t.Errorf("traceparent = %v, want %q", got, testTraceParent)
+	}
+	if got := storedEvent["tracestate"]; got != testTraceState {
+		t.Errorf("tracestate = %v, want %q", got, testTraceState)
+	}
 }
 
 func TestNewHandler(t *testing.T) {
@@ -290,6 +318,8 @@ func TestServeHTTP_ValidCloudEvent(t *testing.T) {
 		"type":        "test.type",
 		"source":      "test/source",
 		"id":          "test-id-123",
+		"traceparent": testTraceParent,
+		"tracestate":  testTraceState,
 		"data":        map[string]string{"key": "value"},
 	}
 
@@ -313,6 +343,8 @@ func TestServeHTTP_ValidCloudEvent(t *testing.T) {
 	if streamInfo.State.Msgs != 1 {
 		t.Errorf("Stream message count = %v, want 1", streamInfo.State.Msgs)
 	}
+
+	assertStoredEventTraceContext(t, js, "TEST_STREAM", "test-id-123")
 }
 
 func TestServeHTTP_BinaryCloudEvent(t *testing.T) {
@@ -367,6 +399,8 @@ func TestServeHTTP_BinaryCloudEvent(t *testing.T) {
 	req.Header.Set("ce-type", "test.type")
 	req.Header.Set("ce-source", "test/source")
 	req.Header.Set("ce-id", "binary-test-id")
+	req.Header.Set("ce-traceparent", testTraceParent)
+	req.Header.Set("ce-tracestate", testTraceState)
 	w := httptest.NewRecorder()
 
 	handler.ServeHTTP(w, req)
@@ -374,6 +408,8 @@ func TestServeHTTP_BinaryCloudEvent(t *testing.T) {
 	if w.Code != http.StatusAccepted {
 		t.Errorf("Status code = %v, want %v", w.Code, http.StatusAccepted)
 	}
+
+	assertStoredEventTraceContext(t, js, "BINARY_STREAM", "binary-test-id")
 }
 
 func TestServeHTTP_MultiplesBrokers(t *testing.T) {

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -11,7 +11,6 @@ import (
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/cloudevents/sdk-go/v2/binding"
-	"github.com/cloudevents/sdk-go/v2/binding/transformer"
 	"github.com/cloudevents/sdk-go/v2/event"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
@@ -27,19 +26,34 @@ var (
 	format = propagation.TraceContext{}
 )
 
+// SerializeTraceTransformers preserves an existing CloudEvents tracing extension,
+// or injects the supplied context when the event does not already have one.
 func SerializeTraceTransformers(ctx context.Context) []binding.Transformer {
 	headerCarrier := propagation.HeaderCarrier{}
 	format.Inject(ctx, headerCarrier)
-	return []binding.Transformer{
-		keyValTransformer(traceParentHeader, headerCarrier.Get(traceParentHeader)),
-		keyValTransformer(traceStateHeader, headerCarrier.Get(traceStateHeader)),
-	}
-}
 
-func keyValTransformer(key string, value string) binding.TransformerFunc {
-	return transformer.SetExtension(key, func(_ interface{}) (interface{}, error) {
-		return value, nil
-	})
+	return []binding.Transformer{binding.TransformerFunc(func(reader binding.MessageMetadataReader, writer binding.MessageMetadataWriter) error {
+		// The CloudEvents tracing extension represents the starting trace of a
+		// multi-hop transmission. Intermediaries must not replace it with a hop context.
+		if traceParent, ok := reader.GetExtension(traceParentHeader).(string); ok && traceParent != "" {
+			return nil
+		}
+
+		traceParent := headerCarrier.Get(traceParentHeader)
+		if traceParent == "" {
+			return nil
+		}
+
+		if err := writer.SetExtension(traceParentHeader, traceParent); err != nil {
+			return err
+		}
+
+		traceState := headerCarrier.Get(traceStateHeader)
+		if traceState == "" {
+			return writer.SetExtension(traceStateHeader, nil)
+		}
+		return writer.SetExtension(traceStateHeader, traceState)
+	})}
 }
 
 func StartTraceFromMessage(logger *zap.Logger, inCtx context.Context, message *event.Event, tracer trace.Tracer, spanName string) (context.Context, trace.Span) {

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -129,18 +129,95 @@ func TestStartTraceFromMessageTraceStateIsNil(t *testing.T) {
 }
 
 func TestSerializeTraceTransformers(t *testing.T) {
-	msg := cloudevents.NewEvent()
-	headerCarrier := propagation.HeaderCarrier{}
-	headerCarrier.Set(traceParentHeader, tp)
-	headerCarrier.Set(traceStateHeader, ts)
-	ctx := format.Extract(context.Background(), headerCarrier)
-	transformers := SerializeTraceTransformers(ctx)
-	message := binding.ToMessage(&msg)
-	event, _ := binding.ToEvent(context.Background(), message, transformers...)
-	if tp != event.Extensions()[traceParentHeader] {
-		t.Fatalf("Traceparent is incorrect, expected: %v, actual: %v", tp, event.Extensions()[traceParentHeader])
+	const existingTraceParent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	const existingTraceState = "vendor=value"
+
+	contextWithTrace := func(traceParent, traceState string) context.Context {
+		headerCarrier := propagation.HeaderCarrier{}
+		headerCarrier.Set(traceParentHeader, traceParent)
+		if traceState != "" {
+			headerCarrier.Set(traceStateHeader, traceState)
+		}
+		return format.Extract(context.Background(), headerCarrier)
 	}
-	if ts != event.Extensions()[traceStateHeader] {
-		t.Fatalf("Tracestate is incorrect, expected: %v, actual: %v", tp, event.Extensions()[traceStateHeader])
+
+	tests := []struct {
+		name                string
+		ctx                 context.Context
+		existingTraceParent interface{}
+		existingTraceState  interface{}
+		wantTraceParent     interface{}
+		wantTraceState      interface{}
+	}{
+		{
+			name:            "inject context when extension is absent",
+			ctx:             contextWithTrace(tp, ts),
+			wantTraceParent: tp,
+			wantTraceState:  ts,
+		},
+		{
+			name:                "preserve existing extension",
+			ctx:                 contextWithTrace(tp, ts),
+			existingTraceParent: existingTraceParent,
+			existingTraceState:  existingTraceState,
+			wantTraceParent:     existingTraceParent,
+			wantTraceState:      existingTraceState,
+		},
+		{
+			name:                "do not mix intermediary tracestate into existing traceparent",
+			ctx:                 contextWithTrace(tp, ts),
+			existingTraceParent: existingTraceParent,
+			wantTraceParent:     existingTraceParent,
+		},
+		{
+			name: "do not add empty extensions without context",
+			ctx:  context.Background(),
+		},
+		{
+			name:               "remove stale tracestate when injecting a new traceparent",
+			ctx:                contextWithTrace(tp, ""),
+			existingTraceState: existingTraceState,
+			wantTraceParent:    tp,
+		},
+		{
+			name:                "preserve existing extension without context",
+			ctx:                 context.Background(),
+			existingTraceParent: existingTraceParent,
+			existingTraceState:  existingTraceState,
+			wantTraceParent:     existingTraceParent,
+			wantTraceState:      existingTraceState,
+		},
+		{
+			name:                "preserve non-empty extension without parsing it",
+			ctx:                 contextWithTrace(tp, ts),
+			existingTraceParent: "invalid-but-owned-by-the-producer",
+			existingTraceState:  existingTraceState,
+			wantTraceParent:     "invalid-but-owned-by-the-producer",
+			wantTraceState:      existingTraceState,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			msg := cloudevents.NewEvent()
+			if test.existingTraceParent != nil {
+				msg.SetExtension(traceParentHeader, test.existingTraceParent)
+			}
+			if test.existingTraceState != nil {
+				msg.SetExtension(traceStateHeader, test.existingTraceState)
+			}
+
+			message := binding.ToMessage(&msg)
+			event, err := binding.ToEvent(context.Background(), message, SerializeTraceTransformers(test.ctx)...)
+			if err != nil {
+				t.Fatalf("Failed to transform event: %v", err)
+			}
+			if got := event.Extensions()[traceParentHeader]; got != test.wantTraceParent {
+				t.Fatalf("Traceparent is incorrect, expected: %v, actual: %v", test.wantTraceParent, got)
+			}
+			if got := event.Extensions()[traceStateHeader]; got != test.wantTraceState {
+				t.Fatalf("Tracestate is incorrect, expected: %v, actual: %v", test.wantTraceState, got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

`SerializeTraceTransformers` no longer unconditionally overwrites the CloudEvents `traceparent` and `tracestate` extensions when an event is serialized.

It now preserves trace context already present on the event and injects the serializer's context only when the event does not contain `traceparent`. This prevents the native NATS Broker ingress from erasing producer-supplied trace context before storing the event in JetStream.

## Why

`SerializeTraceTransformers` previously replaced both CloudEvents tracing extensions on every write.

The native NATS Broker ingress currently has no server trace context, so a producer's valid trace context was replaced with empty values before the event was stored in JetStream. With an instrumented intermediary, it could instead be replaced by the context of that intermediary hop.

The [CloudEvents Distributed Tracing Extension](https://github.com/cloudevents/spec/blob/main/cloudevents/extensions/distributed-tracing.md) requires a multi-hop transmission to retain the starting trace. Middleware may add the extension when the producer omitted it, but must not overwrite an existing one.

## User Impact

```mermaid
sequenceDiagram
    participant P as Producer
    participant I as Broker Ingress
    participant J as JetStream
    participant D as Dispatcher
    participant S as Subscriber

    P->>I: CloudEvent with trace context
    rect rgb(255, 225, 225)
    Note over I: Before: trace context was overwritten
    end
    rect rgb(225, 255, 225)
    Note over I: After: producer trace context is preserved
    end
    I->>J: CloudEvent with original trace context
    J->>D: CloudEvent with original trace context
    D->>S: CloudEvent with original trace context
    Note over S: Spans correlate with the producer trace
```

Consumers can now correlate their messaging spans with the producer's original trace across the complete delivery path.

**Release Note**

```release-note
🐛 Preserve producer-supplied CloudEvents trace context when events pass through the native NATS Broker ingress.
```

**Docs**

No documentation changes are required.
